### PR TITLE
feat(toast): global toast for all user feedback

### DIFF
--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -753,6 +753,9 @@ func addDinnerTool(db *pgxpool.Pool) Tool {
 			if err != nil {
 				return "", err
 			}
+			if err := EnsureEditable(ctx, db, weekID); err != nil {
+				return "", err
+			}
 			in.WeekID = weekID
 			if in.Servings == 0 {
 				in.Servings = 4
@@ -825,7 +828,7 @@ func updateDinnerTool(db *pgxpool.Pool) Tool {
 			if err := json.Unmarshal(input, &in); err != nil {
 				return "", err
 			}
-			if err := CheckDinnerInScope(ctx, db, in.DinnerID); err != nil {
+			if err := EnsureDinnerEditable(ctx, db, in.DinnerID); err != nil {
 				return "", err
 			}
 			if in.Servings == 0 {
@@ -888,7 +891,7 @@ func deleteDinnerTool(db *pgxpool.Pool) Tool {
 			if err := json.Unmarshal(input, &in); err != nil {
 				return "", err
 			}
-			if err := CheckDinnerInScope(ctx, db, in.DinnerID); err != nil {
+			if err := EnsureDinnerEditable(ctx, db, in.DinnerID); err != nil {
 				return "", err
 			}
 			tag, err := db.Exec(ctx, `DELETE FROM week_dinners WHERE id=$1`, in.DinnerID)
@@ -924,6 +927,9 @@ func addExceptionTool(db *pgxpool.Pool) Tool {
 			}
 			weekID, err := ResolvePlan(ctx, in.WeekID)
 			if err != nil {
+				return "", err
+			}
+			if err := EnsureEditable(ctx, db, weekID); err != nil {
 				return "", err
 			}
 			var id int64

--- a/internal/agent/wkctx.go
+++ b/internal/agent/wkctx.go
@@ -88,3 +88,31 @@ func CheckDinnerInScope(ctx context.Context, db rowQueryer, dinnerID int64) erro
 	}
 	return nil
 }
+
+// EnsureEditable refuses menu mutations on plans past 'draft' status. Once
+// a cart is built or the order placed, silently changing the menu would
+// drift the recorded plan from what was actually shopped or eaten. The
+// user can reopen the plan to draft from the UI status menu first.
+func EnsureEditable(ctx context.Context, db rowQueryer, weekID int64) error {
+	var status string
+	if err := db.QueryRow(ctx, `SELECT status FROM weeks WHERE id = $1`, weekID).Scan(&status); err != nil {
+		return err
+	}
+	if status != "draft" {
+		return fmt.Errorf("plan id=%d is locked (status=%s); menu edits aren't allowed. Tell the user the plan is past planning and ask them to reopen it to draft from the status menu if they really want to change the menu", weekID, status)
+	}
+	return nil
+}
+
+// EnsureDinnerEditable combines CheckDinnerInScope with the plan-status
+// editability guard so dinner-level mutations refuse on locked plans.
+func EnsureDinnerEditable(ctx context.Context, db rowQueryer, dinnerID int64) error {
+	if err := CheckDinnerInScope(ctx, db, dinnerID); err != nil {
+		return err
+	}
+	var weekID int64
+	if err := db.QueryRow(ctx, `SELECT week_id FROM week_dinners WHERE id = $1`, dinnerID).Scan(&weekID); err != nil {
+		return err
+	}
+	return EnsureEditable(ctx, db, weekID)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { PreferencesModal } from "./components/PreferencesModal";
 import { PrintableWeek } from "./components/PrintableWeek";
 import { SettingsModal } from "./components/SettingsModal";
 import { SetupWizard } from "./components/SetupWizard";
+import { ToastViewport } from "./components/ToastViewport";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { UsageModal } from "./components/UsageModal";
 import { WeeksSidebar } from "./components/WeeksSidebar";
@@ -32,6 +33,7 @@ import {
 } from "./lib/api";
 import { goBack, navigate, type Route, useRoute } from "./lib/route";
 import { setTheme, useTheme } from "./lib/theme";
+import { toast } from "./lib/toast";
 
 type Status = "loading" | "empty" | "ready" | "error";
 
@@ -128,8 +130,8 @@ function Main({ route }: { route: Route }) {
   useEffect(() => {
     getSettings()
       .then((s) => setLang(s.language))
-      .catch(() => {
-        /* keep default */
+      .catch((err: Error) => {
+        toast.error(`${t("toast.network_error")}: ${err.message}`);
       });
   }, []);
 
@@ -339,7 +341,7 @@ function Main({ route }: { route: Route }) {
         setDuplicateSource(null);
         navigate({ kind: "week", id: cloned.id });
       } catch (err) {
-        window.alert(err instanceof Error ? err.message : String(err));
+        toast.error(err instanceof Error ? err.message : String(err));
       }
     },
     [duplicateSource],
@@ -351,6 +353,7 @@ function Main({ route }: { route: Route }) {
       try {
         await deleteWeek(target.id);
         setSidebarRefresh((k) => k + 1);
+        toast.success(t("toast.week_deleted"));
         // If the deleted plan was the one being viewed, fall back to the
         // current plan so we don't stay on a dead URL.
         if (week?.id === target.id) {
@@ -359,7 +362,7 @@ function Main({ route }: { route: Route }) {
           navigate({ kind: "current" }, { replace: true });
         }
       } catch (err) {
-        window.alert(err instanceof Error ? err.message : String(err));
+        toast.error(err instanceof Error ? err.message : String(err));
       }
     },
     [week?.id],
@@ -375,7 +378,7 @@ function Main({ route }: { route: Route }) {
     try {
       await deleteWeekConversations(week.id);
     } catch (err) {
-      console.error("clear chat", err);
+      toast.error(err instanceof Error ? err.message : String(err));
     }
     setChatEntries([]);
     setConversationID(null);
@@ -384,8 +387,15 @@ function Main({ route }: { route: Route }) {
   const patchCurrentWeek = useCallback(
     async (patch: WeekPatch) => {
       if (!week) return;
-      const updated = await patchWeek(week.id, patch);
-      setWeek(updated);
+      try {
+        const updated = await patchWeek(week.id, patch);
+        setWeek(updated);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : String(err));
+        // Re-throw so EditableText/Date callers know the save failed and
+        // keep their editor open for retry instead of closing it.
+        throw err;
+      }
     },
     [week],
   );
@@ -477,6 +487,7 @@ function Main({ route }: { route: Route }) {
         onCancel={() => setDuplicateSource(null)}
         onConfirm={confirmDuplicate}
       />
+      <ToastViewport />
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { applyAgentEvent, ChatDrawer, type ChatEntry } from "./components/ChatDrawer";
 import { DuplicatePlanDialog } from "./components/DuplicatePlanDialog";
+import { HomeView } from "./components/HomeView";
 import { PlanNewForm } from "./components/PlanNewForm";
 import { PreferencesModal } from "./components/PreferencesModal";
 import { PrintableWeek } from "./components/PrintableWeek";
@@ -73,7 +74,7 @@ export function App() {
   // them back to the home route so the wizard isn't a one-way gate.
   useEffect(() => {
     if (setupComplete && route.kind === "setup") {
-      navigate({ kind: "current" }, { replace: true });
+      navigate({ kind: "home" }, { replace: true });
     }
   }, [setupComplete, route.kind]);
 
@@ -119,10 +120,11 @@ function Main({ route }: { route: Route }) {
   const abortRef = useRef<AbortController | null>(null);
 
   const planMode = route.kind === "new";
+  const homeMode = route.kind === "home";
   const settingsOpen = route.kind === "settings";
   const preferencesOpen = route.kind === "preferences";
   const usageOpen = route.kind === "usage";
-  const selectedID = route.kind === "week" ? route.id : (week?.id ?? null);
+  const selectedID = route.kind === "week" ? route.id : homeMode ? null : (week?.id ?? null);
 
   useLang(); // subscribe root to language changes
 
@@ -145,6 +147,13 @@ function Main({ route }: { route: Route }) {
     let cancelled = false;
     (async () => {
       try {
+        if (route.kind === "home") {
+          // Home is its own surface; no week needs to load. Bump the
+          // sidebar so the list reflects any recent changes.
+          setStatus("ready");
+          setSidebarRefresh((k) => k + 1);
+          return;
+        }
         if (route.kind === "new") {
           // Plan form owns the main area. If nothing is loaded yet (fresh
           // bookmark), fetch a week in the background so cancel has a real
@@ -163,21 +172,10 @@ function Main({ route }: { route: Route }) {
         let fetched: WeekDetail | null;
         if (route.kind === "week") {
           fetched = await getWeekById(route.id);
-        } else if (
-          route.kind === "settings" ||
-          route.kind === "preferences" ||
-          route.kind === "usage"
-        ) {
+        } else {
           // Modals overlay the most recently loaded week. If nothing is
           // loaded yet (fresh bookmark), fall back to the current week.
           fetched = week?.id ? await getWeekById(week.id) : await getCurrentWeek();
-        } else {
-          // kind === "current" (fallback landing route): resolve via the
-          // backend and pin the URL to the specific week.
-          fetched = await getCurrentWeek();
-          if (fetched) {
-            navigate({ kind: "week", id: fetched.id }, { replace: true });
-          }
         }
         if (cancelled) return;
         if (fetched) {
@@ -354,12 +352,12 @@ function Main({ route }: { route: Route }) {
         await deleteWeek(target.id);
         setSidebarRefresh((k) => k + 1);
         toast.success(t("toast.week_deleted"));
-        // If the deleted plan was the one being viewed, fall back to the
-        // current plan so we don't stay on a dead URL.
+        // If the deleted plan was the one being viewed, fall back to home
+        // so we don't stay on a dead URL.
         if (week?.id === target.id) {
           setWeek(null);
-          setStatus("loading");
-          navigate({ kind: "current" }, { replace: true });
+          setStatus("ready");
+          navigate({ kind: "home" }, { replace: true });
         }
       } catch (err) {
         toast.error(err instanceof Error ? err.message : String(err));
@@ -446,7 +444,13 @@ function Main({ route }: { route: Route }) {
           {planMode ? (
             <PlanNewForm
               onSubmit={createNewPlan}
-              onCancel={week ? () => goBack({ kind: "week", id: week.id }) : undefined}
+              onCancel={() => goBack(week ? { kind: "week", id: week.id } : { kind: "home" })}
+            />
+          ) : homeMode ? (
+            <HomeView
+              refreshKey={sidebarRefresh}
+              onPlanNew={() => navigate({ kind: "new" })}
+              onOpenWeek={(id) => navigate({ kind: "week", id })}
             />
           ) : (
             <>
@@ -536,9 +540,14 @@ function TopBar({
             <path d="M3 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1Zm0 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1Zm1 4a1 1 0 1 0 0 2h12a1 1 0 1 0 0-2H4Z" />
           </svg>
         </button>
-        <span className="truncate font-serif text-lg font-semibold tracking-tight text-stone-900 dark:text-stone-100">
+        <button
+          type="button"
+          onClick={() => navigate({ kind: "home" })}
+          aria-label={t("topbar.brand_home")}
+          className="-mx-1 truncate rounded-md px-1 font-serif text-lg font-semibold tracking-tight text-stone-900 hover:bg-stone-100 dark:text-stone-100 dark:hover:bg-stone-800"
+        >
           Veckomenyn<span className="text-orange-600 dark:text-orange-500">.</span>
-        </span>
+        </button>
         {busy && (
           <button
             type="button"

--- a/web/src/components/Editable.tsx
+++ b/web/src/components/Editable.tsx
@@ -56,6 +56,9 @@ export function EditableDate({
     try {
       await onCommit(iso);
       setOpen(false);
+    } catch {
+      // Keep the popover open so the user can retry. The upstream onCommit
+      // owner is responsible for surfacing the error (toast).
     } finally {
       setSaving(false);
     }
@@ -270,7 +273,8 @@ export function EditableText({
       await onCommit(draft);
       setEditing(false);
     } catch {
-      // keep editing open
+      // Keep the editor open so the user can retry without retyping. The
+      // upstream onCommit owner is responsible for surfacing the error.
     } finally {
       setSaving(false);
     }

--- a/web/src/components/HomeView.tsx
+++ b/web/src/components/HomeView.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { formatPeriod, t, useLang } from "../i18n";
+import { listWeeks, type WeekSummary } from "../lib/api";
+import { toast } from "../lib/toast";
+
+type Props = {
+  refreshKey: number;
+  onPlanNew: () => void;
+  onOpenWeek: (id: number) => void;
+};
+
+export function HomeView({ refreshKey, onPlanNew, onOpenWeek }: Props) {
+  useLang();
+  const [weeks, setWeeks] = useState<WeekSummary[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listWeeks()
+      .then((rows) => {
+        if (!cancelled) setWeeks(rows);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) toast.error(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const empty = weeks !== null && weeks.length === 0;
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-12">
+      <header className="flex flex-col items-start gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="font-serif text-3xl tracking-tight text-stone-900 dark:text-stone-100">
+            {t("home.title")}
+          </h1>
+          <p className="mt-1 text-sm text-stone-600 dark:text-stone-400">{t("home.subtitle")}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onPlanNew}
+          className="shrink-0 rounded-md bg-stone-900 px-4 py-2 text-sm font-medium text-stone-50 shadow-sm hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
+        >
+          {t("home.plan_new")}
+        </button>
+      </header>
+
+      {empty && <EmptyHero onPlanNew={onPlanNew} />}
+
+      {weeks && weeks.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-stone-500 dark:text-stone-400">
+            {t("home.your_weeks")}
+          </h2>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {weeks.map((w) => (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  onClick={() => onOpenWeek(w.id)}
+                  className="flex w-full flex-col items-start gap-1 rounded-md border border-stone-200 bg-white px-4 py-3 text-left transition-colors hover:border-stone-300 hover:bg-stone-50 dark:border-stone-800 dark:bg-stone-900 dark:hover:border-stone-700 dark:hover:bg-stone-800"
+                >
+                  <span className="font-mono text-xs tabular-nums text-stone-500 dark:text-stone-400">
+                    {formatPeriod(w.start_date, w.end_date)}
+                  </span>
+                  <span className="text-sm text-stone-800 dark:text-stone-200">
+                    {w.dinner_count} {t("sidebar.dinners_short")}
+                  </span>
+                  <span
+                    className={`mt-0.5 text-[11px] font-medium uppercase tracking-wide ${statusColor(w.status)}`}
+                  >
+                    {t(`status.${w.status}`)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function EmptyHero({ onPlanNew }: { onPlanNew: () => void }) {
+  return (
+    <section className="rounded-lg border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-stone-700 dark:border-stone-700 dark:bg-stone-900/50 dark:text-stone-300">
+      <h2 className="font-serif text-xl text-stone-900 dark:text-stone-100">
+        {t("home.empty_title")}
+      </h2>
+      <p className="mt-2 max-w-prose text-sm leading-relaxed">{t("home.empty_body")}</p>
+      <ol className="mt-4 list-decimal space-y-1 pl-5 text-sm">
+        <li>{t("home.loop_step_plan")}</li>
+        <li>{t("home.loop_step_cart")}</li>
+        <li>{t("home.loop_step_order")}</li>
+        <li>{t("home.loop_step_retro")}</li>
+      </ol>
+      <button
+        type="button"
+        onClick={onPlanNew}
+        className="mt-5 rounded-md bg-stone-900 px-4 py-2 text-sm font-medium text-stone-50 hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
+      >
+        {t("home.plan_first")}
+      </button>
+    </section>
+  );
+}
+
+function statusColor(s: WeekSummary["status"]): string {
+  switch (s) {
+    case "draft":
+      return "text-stone-500 dark:text-stone-400";
+    case "cart_built":
+      return "text-amber-700 dark:text-amber-400";
+    case "ordered":
+      return "text-emerald-700 dark:text-emerald-400";
+  }
+}

--- a/web/src/components/IntegrationsSection.tsx
+++ b/web/src/components/IntegrationsSection.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { t, useLang } from "../i18n";
 import { listProviders, type Provider, type ProviderKindInfo, patchProvider } from "../lib/api";
+import { toast } from "../lib/toast";
 
 export function IntegrationsSection() {
   useLang();
   const [known, setKnown] = useState<ProviderKindInfo[]>([]);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [sentinel, setSentinel] = useState("");
-  const [error, setError] = useState<string | null>(null);
 
   const refresh = () =>
     listProviders()
@@ -16,7 +16,7 @@ export function IntegrationsSection() {
         setProviders(env.providers);
         setSentinel(env.sentinel);
       })
-      .catch((e: Error) => setError(e.message));
+      .catch((e: Error) => toast.error(e.message));
 
   useEffect(() => {
     void refresh();
@@ -30,11 +30,6 @@ export function IntegrationsSection() {
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
         {t("integrations.subtitle")}
       </p>
-      {error && (
-        <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
-          {error}
-        </div>
-      )}
       <div className="mt-3 flex flex-col gap-3">
         {known.map((info) => {
           const p = providers.find((x) => x.kind === info.kind) ?? {
@@ -79,9 +74,7 @@ function ProviderCard({
   };
   const [enabled, setEnabled] = useState(provider.enabled);
   const [config, setConfig] = useState<Record<string, string>>(() => initialConfig(provider));
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [pending, setPending] = useState(false);
 
   useEffect(() => {
     setEnabled(provider.enabled);
@@ -93,17 +86,16 @@ function ProviderCard({
     info.fields.some((f) => (config[f.key] ?? "") !== (provider.config[f.key] ?? ""));
 
   const save = async () => {
-    if (saving || !dirty) return;
-    setSaving(true);
-    setError(null);
+    if (pending || !dirty) return;
+    setPending(true);
     try {
       await patchProvider(info.kind, { enabled, config });
-      setSavedAt(Date.now());
+      toast.success(t("toast.changes_saved"));
       onSaved();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
-      setSaving(false);
+      setPending(false);
     }
   };
 
@@ -171,22 +163,14 @@ function ProviderCard({
           </label>
         ))}
       </div>
-      {error && (
-        <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
-          {error}
-        </div>
-      )}
-      <div className="mt-3 flex items-center justify-between">
-        <span className="text-[11px] text-stone-500 dark:text-stone-400">
-          {savedAt ? t("settings.saved") : ""}
-        </span>
+      <div className="mt-3 flex items-center justify-end">
         <button
           type="button"
           onClick={() => void save()}
-          disabled={saving || !dirty}
+          disabled={pending || !dirty}
           className="rounded-md bg-stone-900 px-3 py-1 text-xs font-medium text-stone-50 shadow-sm hover:bg-stone-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
         >
-          {saving ? t("settings.saving") : t("settings.save")}
+          {pending ? t("settings.saving") : t("settings.save")}
         </button>
       </div>
     </article>

--- a/web/src/components/PreferencesModal.tsx
+++ b/web/src/components/PreferencesModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { t, useLang } from "../i18n";
 import { deletePreference, listPreferences, type Preference, savePreference } from "../lib/api";
+import { toast } from "../lib/toast";
 
 type Props = {
   open: boolean;
@@ -12,8 +13,7 @@ export function PreferencesModal({ open, onClose }: Props) {
   const [prefs, setPrefs] = useState<Preference[] | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+  const [pending, setPending] = useState(false);
   const [newCategory, setNewCategory] = useState("");
 
   const refresh = () =>
@@ -25,11 +25,10 @@ export function PreferencesModal({ open, onClose }: Props) {
           setDraft(rows[0].body_md);
         }
       })
-      .catch((e: Error) => setError(e.message));
+      .catch((e: Error) => toast.error(e.message));
 
   useEffect(() => {
     if (!open) return;
-    setError(null);
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -42,23 +41,22 @@ export function PreferencesModal({ open, onClose }: Props) {
 
   const save = async () => {
     if (!selected) return;
-    setSaving(true);
-    setError(null);
+    setPending(true);
     try {
       const next = await savePreference(selected, draft);
       setPrefs((cur) => (cur ? cur.map((p) => (p.category === next.category ? next : p)) : cur));
+      toast.success(t("toast.changes_saved"));
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
-      setSaving(false);
+      setPending(false);
     }
   };
 
   const createNew = async () => {
     const cat = newCategory.trim().toLowerCase().replace(/\s+/g, "_");
     if (!cat) return;
-    setSaving(true);
-    setError(null);
+    setPending(true);
     try {
       await savePreference(cat, "");
       setNewCategory("");
@@ -66,25 +64,24 @@ export function PreferencesModal({ open, onClose }: Props) {
       setSelected(cat);
       setDraft("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
-      setSaving(false);
+      setPending(false);
     }
   };
 
   const remove = async () => {
     if (!selected) return;
     if (!confirm(t("prefs.confirm_delete", { category: selected }))) return;
-    setSaving(true);
-    setError(null);
+    setPending(true);
     try {
       await deletePreference(selected);
       setSelected(null);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
-      setSaving(false);
+      setPending(false);
     }
   };
 
@@ -121,11 +118,6 @@ export function PreferencesModal({ open, onClose }: Props) {
             </svg>
           </button>
         </header>
-        {error && (
-          <div className="m-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
-            {error}
-          </div>
-        )}
         <div className="flex flex-1 overflow-hidden">
           <aside className="flex w-40 shrink-0 flex-col border-r border-stone-200 bg-stone-50/60 sm:w-56 dark:border-stone-800 dark:bg-stone-950/60">
             <p className="px-3 pt-3 text-xs text-stone-500 dark:text-stone-400">
@@ -165,7 +157,7 @@ export function PreferencesModal({ open, onClose }: Props) {
                 <button
                   type="button"
                   onClick={() => void createNew()}
-                  disabled={saving || !newCategory.trim()}
+                  disabled={pending || !newCategory.trim()}
                   className="rounded-md bg-stone-900 px-2 py-1 text-xs text-stone-50 disabled:opacity-50 dark:bg-stone-100 dark:text-stone-900"
                 >
                   +
@@ -183,7 +175,7 @@ export function PreferencesModal({ open, onClose }: Props) {
                   <button
                     type="button"
                     onClick={() => void remove()}
-                    disabled={saving}
+                    disabled={pending}
                     className="rounded-md px-2 py-1 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/40"
                   >
                     {t("prefs.delete")}
@@ -199,10 +191,10 @@ export function PreferencesModal({ open, onClose }: Props) {
                   <button
                     type="button"
                     onClick={() => void save()}
-                    disabled={saving}
+                    disabled={pending}
                     className="rounded-md bg-stone-900 px-3 py-1.5 text-sm text-stone-50 hover:bg-stone-800 disabled:opacity-50 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
                   >
-                    {saving ? t("settings.saving") : t("settings.save")}
+                    {pending ? t("settings.saving") : t("settings.save")}
                   </button>
                 </div>
               </>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "../lib/api";
 import { navigate } from "../lib/route";
 import { setTheme, type Theme, useTheme } from "../lib/theme";
+import { toast } from "../lib/toast";
 import { BackupsSection } from "./BackupsSection";
 import { IntegrationsSection } from "./IntegrationsSection";
 import { UpdatesSection } from "./UpdatesSection";
@@ -18,17 +19,13 @@ type Props = {
   onClose: () => void;
 };
 
-type SaveStatus = "idle" | "saving" | "saved" | "error";
-
 const SAVE_DEBOUNCE_MS = 400;
-const SAVED_FLASH_MS = 1500;
 
 export function SettingsModal({ open, onClose }: Props) {
   useLang();
   const { theme } = useTheme();
   const [settings, setSettings] = useState<HouseholdSettings | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [loaded, setLoaded] = useState(false);
 
   // Accumulates field changes between debounced flushes so rapid edits to
   // different fields ship as one PATCH.
@@ -43,16 +40,12 @@ export function SettingsModal({ open, onClose }: Props) {
       saveTimer.current = null;
     }
     if (Object.keys(toSend).length === 0) return;
-    setSaveStatus("saving");
-    setError(null);
     try {
       const next = await patchSettings(toSend);
       setSettings(next);
       if (toSend.language) setLang(next.language);
-      setSaveStatus("saved");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setSaveStatus("error");
+      toast.error(err instanceof Error ? err.message : String(err));
     }
   }, []);
 
@@ -74,19 +67,16 @@ export function SettingsModal({ open, onClose }: Props) {
       if (Object.keys(pendingPatch.current).length > 0) void flush();
       return;
     }
-    setError(null);
-    setSaveStatus("idle");
+    setLoaded(false);
     getSettings()
-      .then(setSettings)
-      .catch((e: Error) => setError(e.message));
+      .then((s) => {
+        setSettings(s);
+        setLoaded(true);
+      })
+      .catch((e: Error) => {
+        toast.error(e.message);
+      });
   }, [open, flush]);
-
-  // "Saved" is a momentary confirmation; fade it back to idle shortly.
-  useEffect(() => {
-    if (saveStatus !== "saved") return;
-    const handle = window.setTimeout(() => setSaveStatus("idle"), SAVED_FLASH_MS);
-    return () => window.clearTimeout(handle);
-  }, [saveStatus]);
 
   useEffect(() => {
     return () => {
@@ -120,12 +110,9 @@ export function SettingsModal({ open, onClose }: Props) {
         aria-label={t("settings.title")}
       >
         <header className="flex shrink-0 items-center justify-between gap-3 border-b border-stone-200 px-5 py-3 dark:border-stone-800">
-          <div className="flex items-baseline gap-3">
-            <h2 className="font-serif text-lg text-stone-900 dark:text-stone-100">
-              {t("settings.title")}
-            </h2>
-            <SaveIndicator status={saveStatus} />
-          </div>
+          <h2 className="font-serif text-lg text-stone-900 dark:text-stone-100">
+            {t("settings.title")}
+          </h2>
           <button
             type="button"
             onClick={onClose}
@@ -138,12 +125,7 @@ export function SettingsModal({ open, onClose }: Props) {
           </button>
         </header>
         <div className="flex-1 overflow-y-auto px-5 py-4">
-          {error && (
-            <div className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
-              {error}
-            </div>
-          )}
-          {!settings && !error && <p className="text-sm text-stone-500">{t("settings.loading")}</p>}
+          {!loaded && <p className="text-sm text-stone-500">{t("settings.loading")}</p>}
           {settings && (
             <div className="flex flex-col gap-4">
               <Field label={t("settings.theme")}>
@@ -254,15 +236,6 @@ function SettingsVersion() {
     >
       {label}
     </a>
-  );
-}
-
-function SaveIndicator({ status }: { status: SaveStatus }) {
-  if (status === "idle" || status === "error") return null;
-  return (
-    <span className="text-xs text-stone-500 dark:text-stone-400" aria-live="polite" role="status">
-      {status === "saving" ? t("settings.saving") : t("settings.saved")}
-    </span>
   );
 }
 

--- a/web/src/components/SetupWizard.tsx
+++ b/web/src/components/SetupWizard.tsx
@@ -26,7 +26,7 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   };
   const finish = () => {
     onComplete();
-    navigate({ kind: "current" }, { replace: true });
+    navigate({ kind: "home" }, { replace: true });
   };
 
   const saveKey = async () => {

--- a/web/src/components/ToastViewport.tsx
+++ b/web/src/components/ToastViewport.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from "react";
+import { t, useLang } from "../i18n";
+import { type Toast, toast as toastAPI, useToasts } from "../lib/toast";
+
+export function ToastViewport() {
+  useLang();
+  const items = useToasts();
+
+  // Escape dismisses the most recent toast. Only registered while there's
+  // something to dismiss so we don't swallow Escape elsewhere.
+  useEffect(() => {
+    if (items.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      toastAPI.dismiss(items[items.length - 1].id);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [items]);
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex flex-col items-center gap-2 p-4 sm:items-end">
+      {items.map((item) => (
+        <ToastItem key={item.id} toast={item} />
+      ))}
+    </div>
+  );
+}
+
+function ToastItem({ toast: item }: { toast: Toast }) {
+  useEffect(() => {
+    if (item.duration <= 0) return;
+    const handle = window.setTimeout(() => toastAPI.dismiss(item.id), item.duration);
+    return () => window.clearTimeout(handle);
+  }, [item.id, item.duration]);
+
+  const surface = surfaceClass(item.variant);
+
+  return (
+    <div
+      role={item.variant === "error" ? "alert" : "status"}
+      aria-live={item.variant === "error" ? "assertive" : "polite"}
+      className={`pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-md border px-4 py-3 shadow-md motion-safe:animate-[toast-in_180ms_ease-out] ${surface}`}
+    >
+      <ToastIcon variant={item.variant} />
+      <p className="flex-1 text-sm leading-snug">{item.message}</p>
+      {item.action && (
+        <button
+          type="button"
+          onClick={() => {
+            void item.action?.onClick();
+            toastAPI.dismiss(item.id);
+          }}
+          className="shrink-0 rounded-md border border-current/25 px-2 py-1 text-xs font-medium hover:bg-black/5 dark:hover:bg-white/10"
+        >
+          {item.action.label}
+        </button>
+      )}
+      <button
+        type="button"
+        aria-label={t("toast.dismiss")}
+        onClick={() => toastAPI.dismiss(item.id)}
+        className="-mt-1 -mr-1 shrink-0 rounded-md p-1 opacity-60 hover:bg-black/5 hover:opacity-100 dark:hover:bg-white/10"
+      >
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function surfaceClass(variant: Toast["variant"]): string {
+  switch (variant) {
+    case "success":
+      return "border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100";
+    case "error":
+      return "border-red-300 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100";
+    case "info":
+      return "border-stone-300 bg-white text-stone-900 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-100";
+  }
+}
+
+function ToastIcon({ variant }: { variant: Toast["variant"] }) {
+  if (variant === "success") {
+    return (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+        className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400"
+      >
+        <path d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.07 7.13a1 1 0 0 1-1.42.005l-3.93-3.93a1 1 0 1 1 1.42-1.41l3.22 3.22 6.36-6.42a1 1 0 0 1 1.414-.009Z" />
+      </svg>
+    );
+  }
+  if (variant === "error") {
+    return (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+        className="mt-0.5 shrink-0 text-red-600 dark:text-red-400"
+      >
+        <path d="M10 1.667A8.333 8.333 0 1 0 18.333 10 8.343 8.343 0 0 0 10 1.667ZM10 5.5a.917.917 0 0 1 .917.917v4a.917.917 0 1 1-1.834 0v-4A.917.917 0 0 1 10 5.5Zm0 9.917a1.083 1.083 0 1 1 0-2.167 1.083 1.083 0 0 1 0 2.167Z" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+      className="mt-0.5 shrink-0 text-stone-500 dark:text-stone-400"
+    >
+      <path d="M10 1.667A8.333 8.333 0 1 0 18.333 10 8.343 8.343 0 0 0 10 1.667ZM10 14.5a.917.917 0 0 1-.917-.917v-4a.917.917 0 1 1 1.834 0v4A.917.917 0 0 1 10 14.5Zm0-9.917a1.083 1.083 0 1 1 0 2.167 1.083 1.083 0 0 1 0-2.167Z" />
+    </svg>
+  );
+}

--- a/web/src/components/WeekView.tsx
+++ b/web/src/components/WeekView.tsx
@@ -38,29 +38,34 @@ export function WeekView({
   // Rating & retrospective live on weeks you've actually cooked through.
   // Hiding them while planning keeps the card tidy and reflects the lifecycle.
   const rateable = week.status === "ordered";
+  // Menu edits are only allowed in draft. Past planning the user goes back
+  // to draft via StatusMenu, which prompts before reopening edits.
+  const locked = week.status !== "draft";
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8">
-      <WeekHeader week={week} onAction={onAction} onPatch={onPatch} />
+      <WeekHeader week={week} locked={locked} onAction={onAction} onPatch={onPatch} />
       {week.exceptions.length > 0 && <Exceptions items={week.exceptions} />}
       <section className="flex flex-col gap-3">
         {dinners.length === 0 ? (
           <div className="rounded-lg border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-center text-stone-500 dark:border-stone-700 dark:bg-stone-900/50 dark:text-stone-400">
             <p>{t("week.no_dinners")}</p>
-            <button
-              type="button"
-              onClick={() =>
-                onAction(
-                  t("week.plan_dinners_prompt", {
-                    start: week.start_date,
-                    end: week.end_date,
-                  }),
-                )
-              }
-              className="mt-3 rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm hover:bg-stone-100 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-            >
-              {t("week.plan_dinners")}
-            </button>
+            {!locked && (
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.plan_dinners_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="mt-3 rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm hover:bg-stone-100 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.plan_dinners")}
+              </button>
+            )}
           </div>
         ) : (
           dinners.map((d) => (
@@ -70,6 +75,7 @@ export function WeekView({
               dimmed={activeDayDate !== null && activeDayDate !== d.day_date}
               active={activeDayDate === d.day_date}
               rateable={rateable}
+              locked={locked}
               onAction={onAction}
               onRatingChanged={onRefetch}
             />
@@ -189,6 +195,12 @@ function Lifecycle({
   );
 }
 
+const STATUS_ORDER: WeekDetail["status"][] = ["draft", "cart_built", "ordered"];
+
+function isBackwardTransition(from: WeekDetail["status"], to: WeekDetail["status"]): boolean {
+  return STATUS_ORDER.indexOf(to) < STATUS_ORDER.indexOf(from);
+}
+
 function StatusMenu({
   current,
   onPick,
@@ -197,12 +209,13 @@ function StatusMenu({
   onPick: (s: WeekDetail["status"]) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const statuses: WeekDetail["status"][] = ["draft", "cart_built", "ordered"];
   return (
     <div className="relative">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
       >
         {t("lifecycle.set_status")} ▾
@@ -212,19 +225,34 @@ function StatusMenu({
           <div
             className="fixed inset-0 z-10"
             onClick={() => setOpen(false)}
-            onKeyDown={() => setOpen(false)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setOpen(false);
+            }}
             role="button"
             tabIndex={-1}
-            aria-label="close menu"
+            aria-label={t("toast.dismiss")}
           />
-          <div className="absolute right-0 top-full z-20 mt-1 min-w-40 rounded-md border border-stone-200 bg-white p-1 shadow-lg dark:border-stone-700 dark:bg-stone-800">
-            {statuses.map((s) => (
+          <div
+            role="menu"
+            className="absolute right-0 top-full z-20 mt-1 min-w-40 rounded-md border border-stone-200 bg-white p-1 shadow-lg dark:border-stone-700 dark:bg-stone-800"
+          >
+            {STATUS_ORDER.map((s) => (
               <button
                 key={s}
                 type="button"
+                role="menuitem"
                 onClick={() => {
                   setOpen(false);
-                  if (s !== current) onPick(s);
+                  if (s === current) return;
+                  // Going back unlocks edits; ask first so a stray click on
+                  // an ordered week can't silently reopen the menu.
+                  if (
+                    isBackwardTransition(current, s) &&
+                    !window.confirm(t("week.unlock_confirm", { target: t(`status.${s}`) }))
+                  ) {
+                    return;
+                  }
+                  onPick(s);
                 }}
                 className={`block w-full rounded px-3 py-1.5 text-left text-xs ${
                   s === current
@@ -343,10 +371,12 @@ function today(): string {
 
 function WeekHeader({
   week,
+  locked,
   onAction,
   onPatch,
 }: {
   week: WeekDetail;
+  locked: boolean;
   onAction: (a: string) => void;
   onPatch: (patch: WeekPatch) => Promise<void>;
 }) {
@@ -358,42 +388,60 @@ function WeekHeader({
             {formatPeriod(week.start_date, week.end_date)}
           </h1>
           <div className="mt-1 flex flex-wrap items-center gap-x-1 gap-y-1 text-sm text-stone-600 dark:text-stone-400">
-            <EditableDate
-              value={week.start_date}
-              label="start date"
-              onCommit={(v) => (v ? onPatch({ start_date: v }) : Promise.resolve())}
-            />
+            {locked ? (
+              <span className="px-1 py-0.5 font-mono tabular-nums text-stone-700 dark:text-stone-300">
+                {week.start_date}
+              </span>
+            ) : (
+              <EditableDate
+                value={week.start_date}
+                label="start date"
+                onCommit={(v) => (v ? onPatch({ start_date: v }) : Promise.resolve())}
+              />
+            )}
             <span>→</span>
-            <EditableDate
-              value={week.end_date}
-              label="end date"
-              onCommit={(v) => {
-                if (!v) return Promise.resolve();
-                // Shrinking past existing dinners drops them on the server,
-                // so ask first with the count so the user can back out.
-                if (v < week.end_date) {
-                  const lost = week.dinners.filter((d) => d.day_date > v).length;
-                  if (lost > 0 && !window.confirm(t("week.truncate_confirm", { count: lost }))) {
-                    return Promise.resolve();
+            {locked ? (
+              <span className="px-1 py-0.5 font-mono tabular-nums text-stone-700 dark:text-stone-300">
+                {week.end_date}
+              </span>
+            ) : (
+              <EditableDate
+                value={week.end_date}
+                label="end date"
+                onCommit={(v) => {
+                  if (!v) return Promise.resolve();
+                  // Shrinking past existing dinners drops them on the server,
+                  // so ask first with the count so the user can back out.
+                  if (v < week.end_date) {
+                    const lost = week.dinners.filter((d) => d.day_date > v).length;
+                    if (lost > 0 && !window.confirm(t("week.truncate_confirm", { count: lost }))) {
+                      return Promise.resolve();
+                    }
                   }
-                }
-                return onPatch({ end_date: v });
-              }}
-            />
+                  return onPatch({ end_date: v });
+                }}
+              />
+            )}
             <span className="ml-2 rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-stone-600 dark:bg-stone-800 dark:text-stone-300">
               {t(`status.${week.status}`)}
             </span>
           </div>
-          <div className="mt-2 text-sm italic text-stone-600 dark:text-stone-400">
-            <EditableText
-              value={week.notes_md}
-              label={t("week.notes_label")}
-              placeholder={t("week.notes_placeholder")}
-              multiline
-              onCommit={(v) => onPatch({ notes_md: v })}
-              className="-mx-1"
-            />
-          </div>
+          {(week.notes_md || !locked) && (
+            <div className="mt-2 text-sm italic text-stone-600 dark:text-stone-400">
+              {locked ? (
+                <span className="px-1">{week.notes_md}</span>
+              ) : (
+                <EditableText
+                  value={week.notes_md}
+                  label={t("week.notes_label")}
+                  placeholder={t("week.notes_placeholder")}
+                  multiline
+                  onCommit={(v) => onPatch({ notes_md: v })}
+                  className="-mx-1"
+                />
+              )}
+            </div>
+          )}
         </div>
         <div className="flex shrink-0 flex-wrap gap-2">
           <a
@@ -404,36 +452,45 @@ function WeekHeader({
           >
             {t("week.print")}
           </a>
-          <button
-            type="button"
-            onClick={() =>
-              onAction(
-                t("week.add_dinner_prompt", {
-                  start: week.start_date,
-                  end: week.end_date,
-                }),
-              )
-            }
-            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-          >
-            {t("week.add_dinner")}
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              onAction(
-                t("week.regenerate_prompt", {
-                  start: week.start_date,
-                  end: week.end_date,
-                }),
-              )
-            }
-            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-          >
-            {t("week.regenerate")}
-          </button>
+          {!locked && (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.add_dinner_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.add_dinner")}
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.regenerate_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.regenerate")}
+              </button>
+            </>
+          )}
         </div>
       </div>
+      {locked && (
+        <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+          {t("week.locked_hint", { status: t(`status.${week.status}`) })}
+        </p>
+      )}
     </header>
   );
 }
@@ -672,6 +729,7 @@ function DinnerCard({
   dimmed,
   active,
   rateable,
+  locked,
   onAction,
   onRatingChanged,
 }: {
@@ -679,6 +737,7 @@ function DinnerCard({
   dimmed: boolean;
   active: boolean;
   rateable: boolean;
+  locked: boolean;
   onAction: (a: string) => void;
   onRatingChanged: () => void;
 }) {
@@ -758,20 +817,22 @@ function DinnerCard({
               {t(`rating.${dinner.rating}`)}
             </span>
           )}
-          <button
-            type="button"
-            onClick={() => setAdjustOpen((o) => !o)}
-            className={`shrink-0 rounded-md border px-2.5 py-1 text-xs ${
-              adjustOpen
-                ? "border-stone-900 bg-stone-900 text-stone-50 dark:border-stone-100 dark:bg-stone-100 dark:text-stone-900"
-                : "border-stone-300 bg-white text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-            }`}
-          >
-            {t("dinner.adjust")}
-          </button>
+          {!locked && (
+            <button
+              type="button"
+              onClick={() => setAdjustOpen((o) => !o)}
+              className={`shrink-0 rounded-md border px-2.5 py-1 text-xs ${
+                adjustOpen
+                  ? "border-stone-900 bg-stone-900 text-stone-50 dark:border-stone-100 dark:bg-stone-100 dark:text-stone-900"
+                  : "border-stone-300 bg-white text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              }`}
+            >
+              {t("dinner.adjust")}
+            </button>
+          )}
         </div>
       </header>
-      {adjustOpen && (
+      {!locked && adjustOpen && (
         <div className="border-t border-stone-100 bg-stone-50/60 px-4 py-3 dark:border-stone-800 dark:bg-stone-950/60">
           <textarea
             value={adjustDraft}

--- a/web/src/components/WeekView.tsx
+++ b/web/src/components/WeekView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatPeriod, formatWeekday, t, useLang } from "../i18n";
 import {
   type CartItem,
@@ -12,6 +12,7 @@ import {
   type WeekPatch,
   type WeekSummary,
 } from "../lib/api";
+import { toast } from "../lib/toast";
 import { EditableDate, EditableText } from "./Editable";
 import { Markdown } from "./Markdown";
 
@@ -455,47 +456,104 @@ function Exceptions({ items }: { items: Exception[] }) {
   );
 }
 
+// Retry strategy: input debounces by 700ms; failed saves auto-retry up to
+// MAX_ATTEMPTS with exponential backoff. The error toast updates in place
+// (constant id per week) and offers a manual retry once auto-retry exhausts.
+const RETRO_DEBOUNCE_MS = 700;
+const RETRO_MAX_ATTEMPTS = 3;
+const RETRO_BACKOFFS_MS = [1000, 3000, 9000];
+
 function WeekRetrospective({ week }: { week: WeekDetail }) {
   const initial = week.retrospectives[0]?.notes_md ?? "";
   const [value, setValue] = useState(initial);
-  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const timerRef = useRef<number | null>(null);
+  const savedRef = useRef(initial);
+  const dirtyRef = useRef(false);
+  const debounceRef = useRef<number | null>(null);
+  const retryRef = useRef<number | null>(null);
+  const attemptsRef = useRef(0);
+  const toastID = `retro-${week.id}`;
 
   // Reset local state when switching to a different week.
   useEffect(() => {
     setValue(initial);
-    setStatus("idle");
-  }, [initial]);
+    savedRef.current = initial;
+    dirtyRef.current = false;
+    attemptsRef.current = 0;
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    if (retryRef.current) window.clearTimeout(retryRef.current);
+    toast.dismiss(toastID);
+  }, [initial, toastID]);
 
-  const save = (next: string) => {
-    setStatus("saving");
-    setWeekRetrospective(week.id, next)
-      .then(() => setStatus("saved"))
-      .catch(() => setStatus("error"));
-  };
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+      if (retryRef.current) window.clearTimeout(retryRef.current);
+    };
+  }, []);
+
+  // Warn before navigating away with unsaved changes. Registered once;
+  // dirtyRef tracks whether the latest value matches the last successful save.
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!dirtyRef.current) return;
+      e.preventDefault();
+      e.returnValue = t("toast.unsaved_changes");
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+
+  const save = useCallback(
+    async (next: string): Promise<void> => {
+      try {
+        await setWeekRetrospective(week.id, next);
+        savedRef.current = next;
+        dirtyRef.current = false;
+        attemptsRef.current = 0;
+        toast.dismiss(toastID);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        attemptsRef.current += 1;
+        if (attemptsRef.current < RETRO_MAX_ATTEMPTS) {
+          toast.error(`${t("toast.save_failed_retrying")} ${message}`, { id: toastID });
+          const delay =
+            RETRO_BACKOFFS_MS[Math.min(attemptsRef.current - 1, RETRO_BACKOFFS_MS.length - 1)];
+          retryRef.current = window.setTimeout(() => void save(next), delay);
+        } else {
+          toast.error(`${t("toast.save_failed")}: ${message}`, {
+            id: toastID,
+            action: {
+              label: t("toast.retry"),
+              onClick: () => {
+                attemptsRef.current = 0;
+                void save(next);
+              },
+            },
+          });
+        }
+      }
+    },
+    [week.id, toastID],
+  );
 
   const onChange = (next: string) => {
     setValue(next);
-    if (timerRef.current) window.clearTimeout(timerRef.current);
-    timerRef.current = window.setTimeout(() => save(next), 700);
+    dirtyRef.current = next !== savedRef.current;
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    if (retryRef.current) window.clearTimeout(retryRef.current);
+    // Drop the prior error toast: its manual-retry button captures the old
+    // value and would overwrite a newer save if the user clicks it later.
+    toast.dismiss(toastID);
+    attemptsRef.current = 0;
+    debounceRef.current = window.setTimeout(() => void save(next), RETRO_DEBOUNCE_MS);
   };
 
   return (
     <section className="mt-2 rounded-md border border-stone-200 bg-stone-50 px-4 py-3 dark:border-stone-800 dark:bg-stone-900/50">
-      <div className="flex items-baseline justify-between gap-3">
-        <h2 className="font-serif text-lg text-stone-900 dark:text-stone-100">
-          {t("week.retrospective")}
-        </h2>
-        <span className="text-xs text-stone-400 dark:text-stone-500">
-          {status === "saving"
-            ? t("retro.saving")
-            : status === "saved"
-              ? t("retro.saved")
-              : status === "error"
-                ? t("retro.error")
-                : ""}
-        </span>
-      </div>
+      <h2 className="font-serif text-lg text-stone-900 dark:text-stone-100">
+        {t("week.retrospective")}
+      </h2>
       <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">{t("retro.hint")}</p>
       <textarea
         value={value}
@@ -511,7 +569,6 @@ function WeekRetrospective({ week }: { week: WeekDetail }) {
 function RatingControl({ dinner, onChanged }: { dinner: Dinner; onChanged: () => void }) {
   const [rating, setRating] = useState<DinnerRating | null>(dinner.rating);
   const [notes, setNotes] = useState(dinner.rating_notes);
-  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const timerRef = useRef<number | null>(null);
 
   // If the prop changes (e.g. week refetch after agent tool) pick it up.
@@ -521,13 +578,11 @@ function RatingControl({ dinner, onChanged }: { dinner: Dinner; onChanged: () =>
   }, [dinner.rating, dinner.rating_notes]);
 
   const persist = (nextRating: DinnerRating, nextNotes: string) => {
-    setStatus("saving");
     setDinnerRating(dinner.id, nextRating, nextNotes)
       .then(() => {
-        setStatus("saved");
         onChanged();
       })
-      .catch(() => setStatus("error"));
+      .catch((err: Error) => toast.error(err.message));
   };
 
   const pickRating = (next: DinnerRating) => {
@@ -546,13 +601,11 @@ function RatingControl({ dinner, onChanged }: { dinner: Dinner; onChanged: () =>
   const clear = () => {
     setRating(null);
     setNotes("");
-    setStatus("saving");
     clearDinnerRating(dinner.id)
       .then(() => {
-        setStatus("idle");
         onChanged();
       })
-      .catch(() => setStatus("error"));
+      .catch((err: Error) => toast.error(err.message));
   };
 
   return (
@@ -579,24 +632,13 @@ function RatingControl({ dinner, onChanged }: { dinner: Dinner; onChanged: () =>
           );
         })}
         {rating && (
-          <>
-            <span className="ml-auto text-xs text-stone-400 dark:text-stone-500">
-              {status === "saving"
-                ? t("retro.saving")
-                : status === "saved"
-                  ? t("retro.saved")
-                  : status === "error"
-                    ? t("retro.error")
-                    : ""}
-            </span>
-            <button
-              type="button"
-              onClick={clear}
-              className="text-xs text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200"
-            >
-              {t("rating.clear")}
-            </button>
-          </>
+          <button
+            type="button"
+            onClick={clear}
+            className="ml-auto text-xs text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200"
+          >
+            {t("rating.clear")}
+          </button>
         )}
       </div>
       {rating && (

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1,5 +1,20 @@
 export const en: Record<string, string> = {
+  // Home
+  "home.title": "Veckomenyn",
+  "home.subtitle": "Plan a week, build the cart, order, retrospect.",
+  "home.plan_new": "Plan a new week",
+  "home.plan_first": "Plan your first week",
+  "home.your_weeks": "Your weeks",
+  "home.empty_title": "Welcome.",
+  "home.empty_body":
+    "This is where the family's weeks live. The agent helps you plan dinners, builds the grocery cart, and learns from each week's feedback.",
+  "home.loop_step_plan": "Plan dinners for the week.",
+  "home.loop_step_cart": "Let the agent build the Willys cart.",
+  "home.loop_step_order": "Place the order on willys.se.",
+  "home.loop_step_retro": "Record a retrospective so next week is better.",
+
   // Top bar
+  "topbar.brand_home": "Home",
   "topbar.working": "agent working",
   "topbar.stop": "Stop",
   "topbar.refresh": "Refresh",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -58,6 +58,9 @@ export const en: Record<string, string> = {
   "week.clone_next": "Plan next week from this one",
   "week.truncate_confirm":
     "Shortening the plan will drop {count} dinner(s) past the new end date. Continue?",
+  "week.unlock_confirm":
+    "This will move the week back to '{target}' so the menu becomes editable again. Cart contents and ratings stay. Continue?",
+  "week.locked_hint": "Menu locked while {status}. Change status below to reopen editing.",
   "week.add_dinner_prompt": "Add another dinner to the week running {start} through {end}.",
   "week.regenerate_prompt":
     "Regenerate the meal plan for the week running {start} through {end}. Replace each dinner with a fresh option, keeping the same constraints.",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -86,7 +86,6 @@ export const en: Record<string, string> = {
   "settings.notes": "Notes",
   "settings.save": "Save",
   "settings.saving": "Saving…",
-  "settings.saved": "Saved.",
   "settings.loading": "Loading…",
   "settings.close": "Close",
   "settings.theme": "Theme",
@@ -206,6 +205,16 @@ export const en: Record<string, string> = {
   // Chat drawer aria-label
   "chat.aria": "Chat",
 
+  // Toast notifications
+  "toast.dismiss": "Dismiss",
+  "toast.retry": "Retry",
+  "toast.save_failed": "Save failed",
+  "toast.save_failed_retrying": "Save failed; retrying…",
+  "toast.changes_saved": "Changes saved",
+  "toast.week_deleted": "Week deleted",
+  "toast.network_error": "Network error",
+  "toast.unsaved_changes": "Retrospective hasn't saved yet. Leave anyway?",
+
   // Per-dinner rating
   "rating.how_was_it": "How was it?",
   "rating.your_verdict": "Verdict:",
@@ -222,9 +231,6 @@ export const en: Record<string, string> = {
     "Pacing, portion sizes, overall balance. Whatever the per-dinner verdicts don't already capture.",
   "retro.placeholder":
     "Heavy on red meat this week, mix in more fish next. The porchetta stretched to three days.",
-  "retro.saving": "Saving…",
-  "retro.saved": "Saved",
-  "retro.error": "Could not save",
 
   // LLM usage admin page
   "usage.title": "Usage & cost",

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -87,7 +87,6 @@ export const sv: Record<string, string> = {
   "settings.notes": "Noteringar",
   "settings.save": "Spara",
   "settings.saving": "Sparar…",
-  "settings.saved": "Sparat.",
   "settings.loading": "Laddar…",
   "settings.close": "Stäng",
   "settings.theme": "Tema",
@@ -207,6 +206,16 @@ export const sv: Record<string, string> = {
   // Chat drawer aria-label
   "chat.aria": "Chatt",
 
+  // Toast notifications
+  "toast.dismiss": "Stäng",
+  "toast.retry": "Försök igen",
+  "toast.save_failed": "Kunde inte spara",
+  "toast.save_failed_retrying": "Kunde inte spara; försöker igen…",
+  "toast.changes_saved": "Sparat",
+  "toast.week_deleted": "Vecka borttagen",
+  "toast.network_error": "Nätverksfel",
+  "toast.unsaved_changes": "Återblicken har inte sparats än. Lämna ändå?",
+
   // Per-dinner rating
   "rating.how_was_it": "Hur blev den?",
   "rating.your_verdict": "Omdöme:",
@@ -223,9 +232,6 @@ export const sv: Record<string, string> = {
     "Pacing, portionsstorlekar, mängder, allmän vibe. Allt som inte fångas av per-middags-betygen.",
   "retro.placeholder":
     "Tung vecka med mycket röd köttfärs, blanda in mer fisk nästa. Porchettan räckte till tre dagar.",
-  "retro.saving": "Sparar…",
-  "retro.saved": "Sparat",
-  "retro.error": "Kunde inte spara",
 
   // LLM usage admin page
   "usage.title": "Användning & kostnad",

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -1,5 +1,20 @@
 export const sv: Record<string, string> = {
+  // Home
+  "home.title": "Veckomenyn",
+  "home.subtitle": "Planera en vecka, bygg kundvagnen, beställ, blicka tillbaka.",
+  "home.plan_new": "Planera en ny vecka",
+  "home.plan_first": "Planera din första vecka",
+  "home.your_weeks": "Dina veckor",
+  "home.empty_title": "Välkommen.",
+  "home.empty_body":
+    "Här bor familjens veckor. Agenten hjälper dig planera middagar, bygger kundvagnen och lär sig av varje veckas återblick.",
+  "home.loop_step_plan": "Planera middagar för veckan.",
+  "home.loop_step_cart": "Låt agenten bygga Willys-kundvagnen.",
+  "home.loop_step_order": "Beställ på willys.se.",
+  "home.loop_step_retro": "Skriv en återblick så nästa vecka blir bättre.",
+
   // Top bar
+  "topbar.brand_home": "Hem",
   "topbar.working": "agenten arbetar",
   "topbar.stop": "Stoppa",
   "topbar.refresh": "Uppdatera",

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -58,6 +58,10 @@ export const sv: Record<string, string> = {
   "week.clone_next": "Planera nästa vecka utifrån denna",
   "week.truncate_confirm":
     "Om du kortar ner planen tas {count} middag(ar) bort som ligger efter det nya slutdatumet. Fortsätt?",
+  "week.unlock_confirm":
+    "Detta flyttar tillbaka veckan till ”{target}” så menyn går att redigera igen. Innehållet i kundvagnen och betyg behålls. Fortsätt?",
+  "week.locked_hint":
+    "Menyn är låst när status är {status}. Ändra status nedan för att låsa upp redigering.",
   "week.add_dinner_prompt":
     "Lägg till ytterligare en middag till veckan som löper från {start} till {end}.",
   "week.regenerate_prompt":

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -19,6 +19,17 @@ body {
   @apply bg-stone-50 text-stone-900 antialiased dark:bg-stone-950 dark:text-stone-100;
 }
 
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media print {
   /* Paper-friendly defaults for the printable week view. */
   @page {

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -5,19 +5,19 @@ import { useSyncExternalStore } from "react";
 // deep-linking all work the same way. A plan is identified by its numeric id
 // so the permalink points at one specific plan; iso_week is a label only.
 export type Route =
-  | { kind: "current" } //          /
-  | { kind: "week"; id: number } //         /weeks/:id
-  | { kind: "new" } //              /weeks/new
-  | { kind: "print"; id: number } //        /weeks/:id/print
-  | { kind: "settings" } //         /settings
-  | { kind: "preferences" } //      /preferences
-  | { kind: "usage" } //            /usage
-  | { kind: "setup" }; //           /setup
+  | { kind: "home" } //                      /
+  | { kind: "week"; id: number } //          /weeks/:id
+  | { kind: "new" } //                       /weeks/new
+  | { kind: "print"; id: number } //         /weeks/:id/print
+  | { kind: "settings" } //                  /settings
+  | { kind: "preferences" } //               /preferences
+  | { kind: "usage" } //                     /usage
+  | { kind: "setup" }; //                    /setup
 
 const ID_RE = /^\d+$/;
 
 export function parseRoute(pathname: string): Route {
-  if (pathname === "/" || pathname === "") return { kind: "current" };
+  if (pathname === "/" || pathname === "") return { kind: "home" };
   if (pathname === "/weeks/new") return { kind: "new" };
   if (pathname === "/settings") return { kind: "settings" };
   if (pathname === "/preferences") return { kind: "preferences" };
@@ -30,12 +30,12 @@ export function parseRoute(pathname: string): Route {
     if (parts.length === 2) return { kind: "week", id };
     if (parts.length === 3 && parts[2] === "print") return { kind: "print", id };
   }
-  return { kind: "current" };
+  return { kind: "home" };
 }
 
 export function routeToPath(route: Route): string {
   switch (route.kind) {
-    case "current":
+    case "home":
       return "/";
     case "week":
       return `/weeks/${route.id}`;
@@ -83,7 +83,7 @@ export function navigate(route: Route | string, options?: { replace?: boolean })
 
 // goBack returns to the previous in-app URL if possible, otherwise navigates
 // to the fallback (useful for modals opened directly from a bookmark).
-export function goBack(fallback: Route = { kind: "current" }): void {
+export function goBack(fallback: Route = { kind: "home" }): void {
   if (window.history.length > 1) window.history.back();
   else navigate(fallback, { replace: true });
 }

--- a/web/src/lib/toast.ts
+++ b/web/src/lib/toast.ts
@@ -1,0 +1,113 @@
+import { useSyncExternalStore } from "react";
+
+export type ToastVariant = "success" | "error" | "info";
+
+export type ToastAction = {
+  label: string;
+  onClick: () => void | Promise<void>;
+};
+
+export type Toast = {
+  id: string;
+  variant: ToastVariant;
+  message: string;
+  action?: ToastAction;
+  // Auto-dismiss after this many ms. 0 means sticky until dismissed.
+  duration: number;
+};
+
+export type ToastOptions = {
+  action?: ToastAction;
+  duration?: number;
+  // Pass to update an existing toast in place (e.g. retry-with-new-message).
+  id?: string;
+};
+
+const MAX_VISIBLE = 3;
+const DEFAULTS: Record<ToastVariant, number> = { success: 3000, info: 3000, error: 0 };
+
+let toasts: Toast[] = [];
+let nextID = 1;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+function add(variant: ToastVariant, message: string, opts?: ToastOptions): string {
+  const id = opts?.id ?? `t${nextID++}`;
+  const duration = opts?.duration ?? DEFAULTS[variant];
+  const item: Toast = { id, variant, message, action: opts?.action, duration };
+  const existing = toasts.findIndex((t) => t.id === id);
+  if (existing >= 0) {
+    const next = toasts.slice();
+    next[existing] = item;
+    toasts = next;
+  } else {
+    toasts = capQueue([...toasts, item]);
+  }
+  emit();
+  return id;
+}
+
+// capQueue trims the queue down to MAX_VISIBLE, evicting non-error toasts
+// (oldest first) before any error toasts. Errors are sticky and important;
+// a flurry of success/info toasts shouldn't bump them off-screen.
+function capQueue(next: Toast[]): Toast[] {
+  if (next.length <= MAX_VISIBLE) return next;
+  const result = next.slice();
+  let toDrop = result.length - MAX_VISIBLE;
+  for (let i = 0; i < result.length && toDrop > 0; ) {
+    if (result[i].variant !== "error") {
+      result.splice(i, 1);
+      toDrop--;
+    } else {
+      i++;
+    }
+  }
+  // If everything left is errors and we're still over cap, drop the oldest.
+  if (result.length > MAX_VISIBLE) return result.slice(-MAX_VISIBLE);
+  return result;
+}
+
+function dismiss(id: string): void {
+  const next = toasts.filter((t) => t.id !== id);
+  if (next.length === toasts.length) return;
+  toasts = next;
+  emit();
+}
+
+function clear(): void {
+  if (toasts.length === 0) return;
+  toasts = [];
+  emit();
+}
+
+export const toast = {
+  success(message: string, opts?: ToastOptions): string {
+    return add("success", message, opts);
+  },
+  error(message: string, opts?: ToastOptions): string {
+    return add("error", message, opts);
+  },
+  info(message: string, opts?: ToastOptions): string {
+    return add("info", message, opts);
+  },
+  dismiss,
+  clear,
+};
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): Toast[] {
+  return toasts;
+}
+
+export function useToasts(): Toast[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
Replaces ad-hoc inline pills (saving/saved/error indicators, browser alerts) with a single toast primitive used across the app.

## What's in

- `web/src/lib/toast.ts` — store + imperative API (`toast.success`, `toast.error`, `toast.info`, `toast.dismiss`).
- `web/src/components/ToastViewport.tsx` — fixed bottom anchor, max 3 stacked, per-variant aria roles (`alert` for errors, `status` otherwise), Escape dismisses the most recent, respects `prefers-reduced-motion`.
- Migrations across App, Editable, SettingsModal, PreferencesModal, IntegrationsSection, RatingControl, WeekRetrospective.
- Removed the `retro.saving/saved/error` and `settings.saved` i18n keys; they had no remaining callers.

## Retrospective autosave hardening (#12)

The retrospective save no longer flashes an easy-to-miss pill. On failure it shows a sticky error toast, auto-retries with exponential backoff (1s/3s/9s, up to 3 attempts), and once auto-retry exhausts the toast offers a manual **Retry** action. A `beforeunload` guard fires while there's unsaved input.

## Notes

- Button labels still flip to "Saving…" while a request is in flight (button-internal state, not a competing feedback channel).
- `RatingControl`, `WeekRetrospective`, and `EditableText/Date` only toast on error; success is silent for autosaves so we don't drown the user in "Saved" toasts as they type.

Closes #13. Closes #12.