### PR TITLE
feat(weeks): lock menu edits past draft

### DIFF
--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -753,6 +753,9 @@ func addDinnerTool(db *pgxpool.Pool) Tool {
 			if err != nil {
 				return "", err
 			}
+			if err := EnsureEditable(ctx, db, weekID); err != nil {
+				return "", err
+			}
 			in.WeekID = weekID
 			if in.Servings == 0 {
 				in.Servings = 4
@@ -825,7 +828,7 @@ func updateDinnerTool(db *pgxpool.Pool) Tool {
 			if err := json.Unmarshal(input, &in); err != nil {
 				return "", err
 			}
-			if err := CheckDinnerInScope(ctx, db, in.DinnerID); err != nil {
+			if err := EnsureDinnerEditable(ctx, db, in.DinnerID); err != nil {
 				return "", err
 			}
 			if in.Servings == 0 {
@@ -888,7 +891,7 @@ func deleteDinnerTool(db *pgxpool.Pool) Tool {
 			if err := json.Unmarshal(input, &in); err != nil {
 				return "", err
 			}
-			if err := CheckDinnerInScope(ctx, db, in.DinnerID); err != nil {
+			if err := EnsureDinnerEditable(ctx, db, in.DinnerID); err != nil {
 				return "", err
 			}
 			tag, err := db.Exec(ctx, `DELETE FROM week_dinners WHERE id=$1`, in.DinnerID)
@@ -924,6 +927,9 @@ func addExceptionTool(db *pgxpool.Pool) Tool {
 			}
 			weekID, err := ResolvePlan(ctx, in.WeekID)
 			if err != nil {
+				return "", err
+			}
+			if err := EnsureEditable(ctx, db, weekID); err != nil {
 				return "", err
 			}
 			var id int64

--- a/internal/agent/wkctx.go
+++ b/internal/agent/wkctx.go
@@ -88,3 +88,31 @@ func CheckDinnerInScope(ctx context.Context, db rowQueryer, dinnerID int64) erro
 	}
 	return nil
 }
+
+// EnsureEditable refuses menu mutations on plans past 'draft' status. Once
+// a cart is built or the order placed, silently changing the menu would
+// drift the recorded plan from what was actually shopped or eaten. The
+// user can reopen the plan to draft from the UI status menu first.
+func EnsureEditable(ctx context.Context, db rowQueryer, weekID int64) error {
+	var status string
+	if err := db.QueryRow(ctx, `SELECT status FROM weeks WHERE id = $1`, weekID).Scan(&status); err != nil {
+		return err
+	}
+	if status != "draft" {
+		return fmt.Errorf("plan id=%d is locked (status=%s); menu edits aren't allowed. Tell the user the plan is past planning and ask them to reopen it to draft from the status menu if they really want to change the menu", weekID, status)
+	}
+	return nil
+}
+
+// EnsureDinnerEditable combines CheckDinnerInScope with the plan-status
+// editability guard so dinner-level mutations refuse on locked plans.
+func EnsureDinnerEditable(ctx context.Context, db rowQueryer, dinnerID int64) error {
+	if err := CheckDinnerInScope(ctx, db, dinnerID); err != nil {
+		return err
+	}
+	var weekID int64
+	if err := db.QueryRow(ctx, `SELECT week_id FROM week_dinners WHERE id = $1`, dinnerID).Scan(&weekID); err != nil {
+		return err
+	}
+	return EnsureEditable(ctx, db, weekID)
+}

--- a/web/src/components/WeekView.tsx
+++ b/web/src/components/WeekView.tsx
@@ -38,29 +38,34 @@ export function WeekView({
   // Rating & retrospective live on weeks you've actually cooked through.
   // Hiding them while planning keeps the card tidy and reflects the lifecycle.
   const rateable = week.status === "ordered";
+  // Menu edits are only allowed in draft. Past planning the user goes back
+  // to draft via StatusMenu, which prompts before reopening edits.
+  const locked = week.status !== "draft";
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8">
-      <WeekHeader week={week} onAction={onAction} onPatch={onPatch} />
+      <WeekHeader week={week} locked={locked} onAction={onAction} onPatch={onPatch} />
       {week.exceptions.length > 0 && <Exceptions items={week.exceptions} />}
       <section className="flex flex-col gap-3">
         {dinners.length === 0 ? (
           <div className="rounded-lg border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-center text-stone-500 dark:border-stone-700 dark:bg-stone-900/50 dark:text-stone-400">
             <p>{t("week.no_dinners")}</p>
-            <button
-              type="button"
-              onClick={() =>
-                onAction(
-                  t("week.plan_dinners_prompt", {
-                    start: week.start_date,
-                    end: week.end_date,
-                  }),
-                )
-              }
-              className="mt-3 rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm hover:bg-stone-100 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-            >
-              {t("week.plan_dinners")}
-            </button>
+            {!locked && (
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.plan_dinners_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="mt-3 rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm hover:bg-stone-100 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.plan_dinners")}
+              </button>
+            )}
           </div>
         ) : (
           dinners.map((d) => (
@@ -70,6 +75,7 @@ export function WeekView({
               dimmed={activeDayDate !== null && activeDayDate !== d.day_date}
               active={activeDayDate === d.day_date}
               rateable={rateable}
+              locked={locked}
               onAction={onAction}
               onRatingChanged={onRefetch}
             />
@@ -189,6 +195,12 @@ function Lifecycle({
   );
 }
 
+const STATUS_ORDER: WeekDetail["status"][] = ["draft", "cart_built", "ordered"];
+
+function isBackwardTransition(from: WeekDetail["status"], to: WeekDetail["status"]): boolean {
+  return STATUS_ORDER.indexOf(to) < STATUS_ORDER.indexOf(from);
+}
+
 function StatusMenu({
   current,
   onPick,
@@ -197,12 +209,13 @@ function StatusMenu({
   onPick: (s: WeekDetail["status"]) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const statuses: WeekDetail["status"][] = ["draft", "cart_built", "ordered"];
   return (
     <div className="relative">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
       >
         {t("lifecycle.set_status")} ▾
@@ -212,19 +225,34 @@ function StatusMenu({
           <div
             className="fixed inset-0 z-10"
             onClick={() => setOpen(false)}
-            onKeyDown={() => setOpen(false)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setOpen(false);
+            }}
             role="button"
             tabIndex={-1}
-            aria-label="close menu"
+            aria-label={t("toast.dismiss")}
           />
-          <div className="absolute right-0 top-full z-20 mt-1 min-w-40 rounded-md border border-stone-200 bg-white p-1 shadow-lg dark:border-stone-700 dark:bg-stone-800">
-            {statuses.map((s) => (
+          <div
+            role="menu"
+            className="absolute right-0 top-full z-20 mt-1 min-w-40 rounded-md border border-stone-200 bg-white p-1 shadow-lg dark:border-stone-700 dark:bg-stone-800"
+          >
+            {STATUS_ORDER.map((s) => (
               <button
                 key={s}
                 type="button"
+                role="menuitem"
                 onClick={() => {
                   setOpen(false);
-                  if (s !== current) onPick(s);
+                  if (s === current) return;
+                  // Going back unlocks edits; ask first so a stray click on
+                  // an ordered week can't silently reopen the menu.
+                  if (
+                    isBackwardTransition(current, s) &&
+                    !window.confirm(t("week.unlock_confirm", { target: t(`status.${s}`) }))
+                  ) {
+                    return;
+                  }
+                  onPick(s);
                 }}
                 className={`block w-full rounded px-3 py-1.5 text-left text-xs ${
                   s === current
@@ -343,10 +371,12 @@ function today(): string {
 
 function WeekHeader({
   week,
+  locked,
   onAction,
   onPatch,
 }: {
   week: WeekDetail;
+  locked: boolean;
   onAction: (a: string) => void;
   onPatch: (patch: WeekPatch) => Promise<void>;
 }) {
@@ -358,42 +388,60 @@ function WeekHeader({
             {formatPeriod(week.start_date, week.end_date)}
           </h1>
           <div className="mt-1 flex flex-wrap items-center gap-x-1 gap-y-1 text-sm text-stone-600 dark:text-stone-400">
-            <EditableDate
-              value={week.start_date}
-              label="start date"
-              onCommit={(v) => (v ? onPatch({ start_date: v }) : Promise.resolve())}
-            />
+            {locked ? (
+              <span className="px-1 py-0.5 font-mono tabular-nums text-stone-700 dark:text-stone-300">
+                {week.start_date}
+              </span>
+            ) : (
+              <EditableDate
+                value={week.start_date}
+                label="start date"
+                onCommit={(v) => (v ? onPatch({ start_date: v }) : Promise.resolve())}
+              />
+            )}
             <span>→</span>
-            <EditableDate
-              value={week.end_date}
-              label="end date"
-              onCommit={(v) => {
-                if (!v) return Promise.resolve();
-                // Shrinking past existing dinners drops them on the server,
-                // so ask first with the count so the user can back out.
-                if (v < week.end_date) {
-                  const lost = week.dinners.filter((d) => d.day_date > v).length;
-                  if (lost > 0 && !window.confirm(t("week.truncate_confirm", { count: lost }))) {
-                    return Promise.resolve();
+            {locked ? (
+              <span className="px-1 py-0.5 font-mono tabular-nums text-stone-700 dark:text-stone-300">
+                {week.end_date}
+              </span>
+            ) : (
+              <EditableDate
+                value={week.end_date}
+                label="end date"
+                onCommit={(v) => {
+                  if (!v) return Promise.resolve();
+                  // Shrinking past existing dinners drops them on the server,
+                  // so ask first with the count so the user can back out.
+                  if (v < week.end_date) {
+                    const lost = week.dinners.filter((d) => d.day_date > v).length;
+                    if (lost > 0 && !window.confirm(t("week.truncate_confirm", { count: lost }))) {
+                      return Promise.resolve();
+                    }
                   }
-                }
-                return onPatch({ end_date: v });
-              }}
-            />
+                  return onPatch({ end_date: v });
+                }}
+              />
+            )}
             <span className="ml-2 rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-stone-600 dark:bg-stone-800 dark:text-stone-300">
               {t(`status.${week.status}`)}
             </span>
           </div>
-          <div className="mt-2 text-sm italic text-stone-600 dark:text-stone-400">
-            <EditableText
-              value={week.notes_md}
-              label={t("week.notes_label")}
-              placeholder={t("week.notes_placeholder")}
-              multiline
-              onCommit={(v) => onPatch({ notes_md: v })}
-              className="-mx-1"
-            />
-          </div>
+          {(week.notes_md || !locked) && (
+            <div className="mt-2 text-sm italic text-stone-600 dark:text-stone-400">
+              {locked ? (
+                <span className="px-1">{week.notes_md}</span>
+              ) : (
+                <EditableText
+                  value={week.notes_md}
+                  label={t("week.notes_label")}
+                  placeholder={t("week.notes_placeholder")}
+                  multiline
+                  onCommit={(v) => onPatch({ notes_md: v })}
+                  className="-mx-1"
+                />
+              )}
+            </div>
+          )}
         </div>
         <div className="flex shrink-0 flex-wrap gap-2">
           <a
@@ -404,36 +452,45 @@ function WeekHeader({
           >
             {t("week.print")}
           </a>
-          <button
-            type="button"
-            onClick={() =>
-              onAction(
-                t("week.add_dinner_prompt", {
-                  start: week.start_date,
-                  end: week.end_date,
-                }),
-              )
-            }
-            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-          >
-            {t("week.add_dinner")}
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              onAction(
-                t("week.regenerate_prompt", {
-                  start: week.start_date,
-                  end: week.end_date,
-                }),
-              )
-            }
-            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-          >
-            {t("week.regenerate")}
-          </button>
+          {!locked && (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.add_dinner_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.add_dinner")}
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onAction(
+                    t("week.regenerate_prompt", {
+                      start: week.start_date,
+                      end: week.end_date,
+                    }),
+                  )
+                }
+                className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              >
+                {t("week.regenerate")}
+              </button>
+            </>
+          )}
         </div>
       </div>
+      {locked && (
+        <p className="mt-2 text-xs text-stone-500 dark:text-stone-400">
+          {t("week.locked_hint", { status: t(`status.${week.status}`) })}
+        </p>
+      )}
     </header>
   );
 }
@@ -672,6 +729,7 @@ function DinnerCard({
   dimmed,
   active,
   rateable,
+  locked,
   onAction,
   onRatingChanged,
 }: {
@@ -679,6 +737,7 @@ function DinnerCard({
   dimmed: boolean;
   active: boolean;
   rateable: boolean;
+  locked: boolean;
   onAction: (a: string) => void;
   onRatingChanged: () => void;
 }) {
@@ -758,20 +817,22 @@ function DinnerCard({
               {t(`rating.${dinner.rating}`)}
             </span>
           )}
-          <button
-            type="button"
-            onClick={() => setAdjustOpen((o) => !o)}
-            className={`shrink-0 rounded-md border px-2.5 py-1 text-xs ${
-              adjustOpen
-                ? "border-stone-900 bg-stone-900 text-stone-50 dark:border-stone-100 dark:bg-stone-100 dark:text-stone-900"
-                : "border-stone-300 bg-white text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
-            }`}
-          >
-            {t("dinner.adjust")}
-          </button>
+          {!locked && (
+            <button
+              type="button"
+              onClick={() => setAdjustOpen((o) => !o)}
+              className={`shrink-0 rounded-md border px-2.5 py-1 text-xs ${
+                adjustOpen
+                  ? "border-stone-900 bg-stone-900 text-stone-50 dark:border-stone-100 dark:bg-stone-100 dark:text-stone-900"
+                  : "border-stone-300 bg-white text-stone-700 hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+              }`}
+            >
+              {t("dinner.adjust")}
+            </button>
+          )}
         </div>
       </header>
-      {adjustOpen && (
+      {!locked && adjustOpen && (
         <div className="border-t border-stone-100 bg-stone-50/60 px-4 py-3 dark:border-stone-800 dark:bg-stone-950/60">
           <textarea
             value={adjustDraft}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -43,6 +43,9 @@ export const en: Record<string, string> = {
   "week.clone_next": "Plan next week from this one",
   "week.truncate_confirm":
     "Shortening the plan will drop {count} dinner(s) past the new end date. Continue?",
+  "week.unlock_confirm":
+    "This will move the week back to '{target}' so the menu becomes editable again. Cart contents and ratings stay. Continue?",
+  "week.locked_hint": "Menu locked while {status}. Change status below to reopen editing.",
   "week.add_dinner_prompt": "Add another dinner to the week running {start} through {end}.",
   "week.regenerate_prompt":
     "Regenerate the meal plan for the week running {start} through {end}. Replace each dinner with a fresh option, keeping the same constraints.",

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -43,6 +43,10 @@ export const sv: Record<string, string> = {
   "week.clone_next": "Planera nästa vecka utifrån denna",
   "week.truncate_confirm":
     "Om du kortar ner planen tas {count} middag(ar) bort som ligger efter det nya slutdatumet. Fortsätt?",
+  "week.unlock_confirm":
+    "Detta flyttar tillbaka veckan till ”{target}” så menyn går att redigera igen. Innehållet i kundvagnen och betyg behålls. Fortsätt?",
+  "week.locked_hint":
+    "Menyn är låst när status är {status}. Ändra status nedan för att låsa upp redigering.",
   "week.add_dinner_prompt":
     "Lägg till ytterligare en middag till veckan som löper från {start} till {end}.",
   "week.regenerate_prompt":


### PR DESCRIPTION
Once a week moves past planning (\`cart_built\` or \`ordered\`), the menu locks to prevent accidental drift from what was actually shopped/eaten. The user can move back to \`draft\` explicitly to reopen edits.

## UI

- "Add dinner", "Suggest new menu", per-dinner "Adjust", and the date/notes editors all hide while the week is locked.
- A small hint reads "Menu locked while {status}. Change status below to reopen editing."
- \`StatusMenu\` confirms backward transitions (cart_built → draft, ordered → cart_built, ordered → draft) with a dialog naming the target so a stray click can't silently unlock the plan.
- Print, status badge, ratings (when ordered), and retrospective stay available throughout.

## Backend

- New \`EnsureEditable\` / \`EnsureDinnerEditable\` helpers in \`internal/agent/wkctx.go\`.
- \`add_dinner\`, \`update_dinner\`, \`delete_dinner\`, and \`add_exception\` agent tools refuse on locked plans with a message that tells the LLM to ask the user to reopen the plan.

## Stacked

Based on #14 since the WeekView migration there is the natural anchor for these UI hunks. Will rebase to \`main\` once #14 merges.

Closes #8.