### PR TITLE
feat(home): landing page that lists weeks and invites a new one

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { applyAgentEvent, ChatDrawer, type ChatEntry } from "./components/ChatDrawer";
 import { DuplicatePlanDialog } from "./components/DuplicatePlanDialog";
+import { HomeView } from "./components/HomeView";
 import { PlanNewForm } from "./components/PlanNewForm";
 import { PreferencesModal } from "./components/PreferencesModal";
 import { PrintableWeek } from "./components/PrintableWeek";
@@ -73,7 +74,7 @@ export function App() {
   // them back to the home route so the wizard isn't a one-way gate.
   useEffect(() => {
     if (setupComplete && route.kind === "setup") {
-      navigate({ kind: "current" }, { replace: true });
+      navigate({ kind: "home" }, { replace: true });
     }
   }, [setupComplete, route.kind]);
 
@@ -119,10 +120,11 @@ function Main({ route }: { route: Route }) {
   const abortRef = useRef<AbortController | null>(null);
 
   const planMode = route.kind === "new";
+  const homeMode = route.kind === "home";
   const settingsOpen = route.kind === "settings";
   const preferencesOpen = route.kind === "preferences";
   const usageOpen = route.kind === "usage";
-  const selectedID = route.kind === "week" ? route.id : (week?.id ?? null);
+  const selectedID = route.kind === "week" ? route.id : homeMode ? null : (week?.id ?? null);
 
   useLang(); // subscribe root to language changes
 
@@ -145,6 +147,13 @@ function Main({ route }: { route: Route }) {
     let cancelled = false;
     (async () => {
       try {
+        if (route.kind === "home") {
+          // Home is its own surface; no week needs to load. Bump the
+          // sidebar so the list reflects any recent changes.
+          setStatus("ready");
+          setSidebarRefresh((k) => k + 1);
+          return;
+        }
         if (route.kind === "new") {
           // Plan form owns the main area. If nothing is loaded yet (fresh
           // bookmark), fetch a week in the background so cancel has a real
@@ -163,21 +172,10 @@ function Main({ route }: { route: Route }) {
         let fetched: WeekDetail | null;
         if (route.kind === "week") {
           fetched = await getWeekById(route.id);
-        } else if (
-          route.kind === "settings" ||
-          route.kind === "preferences" ||
-          route.kind === "usage"
-        ) {
+        } else {
           // Modals overlay the most recently loaded week. If nothing is
           // loaded yet (fresh bookmark), fall back to the current week.
           fetched = week?.id ? await getWeekById(week.id) : await getCurrentWeek();
-        } else {
-          // kind === "current" (fallback landing route): resolve via the
-          // backend and pin the URL to the specific week.
-          fetched = await getCurrentWeek();
-          if (fetched) {
-            navigate({ kind: "week", id: fetched.id }, { replace: true });
-          }
         }
         if (cancelled) return;
         if (fetched) {
@@ -354,12 +352,12 @@ function Main({ route }: { route: Route }) {
         await deleteWeek(target.id);
         setSidebarRefresh((k) => k + 1);
         toast.success(t("toast.week_deleted"));
-        // If the deleted plan was the one being viewed, fall back to the
-        // current plan so we don't stay on a dead URL.
+        // If the deleted plan was the one being viewed, fall back to home
+        // so we don't stay on a dead URL.
         if (week?.id === target.id) {
           setWeek(null);
-          setStatus("loading");
-          navigate({ kind: "current" }, { replace: true });
+          setStatus("ready");
+          navigate({ kind: "home" }, { replace: true });
         }
       } catch (err) {
         toast.error(err instanceof Error ? err.message : String(err));
@@ -446,7 +444,13 @@ function Main({ route }: { route: Route }) {
           {planMode ? (
             <PlanNewForm
               onSubmit={createNewPlan}
-              onCancel={week ? () => goBack({ kind: "week", id: week.id }) : undefined}
+              onCancel={() => goBack(week ? { kind: "week", id: week.id } : { kind: "home" })}
+            />
+          ) : homeMode ? (
+            <HomeView
+              refreshKey={sidebarRefresh}
+              onPlanNew={() => navigate({ kind: "new" })}
+              onOpenWeek={(id) => navigate({ kind: "week", id })}
             />
           ) : (
             <>
@@ -536,9 +540,14 @@ function TopBar({
             <path d="M3 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1Zm0 5a1 1 0 0 1 1-1h12a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1Zm1 4a1 1 0 1 0 0 2h12a1 1 0 1 0 0-2H4Z" />
           </svg>
         </button>
-        <span className="truncate font-serif text-lg font-semibold tracking-tight text-stone-900 dark:text-stone-100">
+        <button
+          type="button"
+          onClick={() => navigate({ kind: "home" })}
+          aria-label={t("topbar.brand_home")}
+          className="-mx-1 truncate rounded-md px-1 font-serif text-lg font-semibold tracking-tight text-stone-900 hover:bg-stone-100 dark:text-stone-100 dark:hover:bg-stone-800"
+        >
           Veckomenyn<span className="text-orange-600 dark:text-orange-500">.</span>
-        </span>
+        </button>
         {busy && (
           <button
             type="button"

--- a/web/src/components/HomeView.tsx
+++ b/web/src/components/HomeView.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { formatPeriod, t, useLang } from "../i18n";
+import { listWeeks, type WeekSummary } from "../lib/api";
+import { toast } from "../lib/toast";
+
+type Props = {
+  refreshKey: number;
+  onPlanNew: () => void;
+  onOpenWeek: (id: number) => void;
+};
+
+export function HomeView({ refreshKey, onPlanNew, onOpenWeek }: Props) {
+  useLang();
+  const [weeks, setWeeks] = useState<WeekSummary[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listWeeks()
+      .then((rows) => {
+        if (!cancelled) setWeeks(rows);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) toast.error(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const empty = weeks !== null && weeks.length === 0;
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-12">
+      <header className="flex flex-col items-start gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="font-serif text-3xl tracking-tight text-stone-900 dark:text-stone-100">
+            {t("home.title")}
+          </h1>
+          <p className="mt-1 text-sm text-stone-600 dark:text-stone-400">{t("home.subtitle")}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onPlanNew}
+          className="shrink-0 rounded-md bg-stone-900 px-4 py-2 text-sm font-medium text-stone-50 shadow-sm hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
+        >
+          {t("home.plan_new")}
+        </button>
+      </header>
+
+      {empty && <EmptyHero onPlanNew={onPlanNew} />}
+
+      {weeks && weeks.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-stone-500 dark:text-stone-400">
+            {t("home.your_weeks")}
+          </h2>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {weeks.map((w) => (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  onClick={() => onOpenWeek(w.id)}
+                  className="flex w-full flex-col items-start gap-1 rounded-md border border-stone-200 bg-white px-4 py-3 text-left transition-colors hover:border-stone-300 hover:bg-stone-50 dark:border-stone-800 dark:bg-stone-900 dark:hover:border-stone-700 dark:hover:bg-stone-800"
+                >
+                  <span className="font-mono text-xs tabular-nums text-stone-500 dark:text-stone-400">
+                    {formatPeriod(w.start_date, w.end_date)}
+                  </span>
+                  <span className="text-sm text-stone-800 dark:text-stone-200">
+                    {w.dinner_count} {t("sidebar.dinners_short")}
+                  </span>
+                  <span
+                    className={`mt-0.5 text-[11px] font-medium uppercase tracking-wide ${statusColor(w.status)}`}
+                  >
+                    {t(`status.${w.status}`)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function EmptyHero({ onPlanNew }: { onPlanNew: () => void }) {
+  return (
+    <section className="rounded-lg border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-stone-700 dark:border-stone-700 dark:bg-stone-900/50 dark:text-stone-300">
+      <h2 className="font-serif text-xl text-stone-900 dark:text-stone-100">
+        {t("home.empty_title")}
+      </h2>
+      <p className="mt-2 max-w-prose text-sm leading-relaxed">{t("home.empty_body")}</p>
+      <ol className="mt-4 list-decimal space-y-1 pl-5 text-sm">
+        <li>{t("home.loop_step_plan")}</li>
+        <li>{t("home.loop_step_cart")}</li>
+        <li>{t("home.loop_step_order")}</li>
+        <li>{t("home.loop_step_retro")}</li>
+      </ol>
+      <button
+        type="button"
+        onClick={onPlanNew}
+        className="mt-5 rounded-md bg-stone-900 px-4 py-2 text-sm font-medium text-stone-50 hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
+      >
+        {t("home.plan_first")}
+      </button>
+    </section>
+  );
+}
+
+function statusColor(s: WeekSummary["status"]): string {
+  switch (s) {
+    case "draft":
+      return "text-stone-500 dark:text-stone-400";
+    case "cart_built":
+      return "text-amber-700 dark:text-amber-400";
+    case "ordered":
+      return "text-emerald-700 dark:text-emerald-400";
+  }
+}

--- a/web/src/components/SetupWizard.tsx
+++ b/web/src/components/SetupWizard.tsx
@@ -26,7 +26,7 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   };
   const finish = () => {
     onComplete();
-    navigate({ kind: "current" }, { replace: true });
+    navigate({ kind: "home" }, { replace: true });
   };
 
   const saveKey = async () => {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1,5 +1,20 @@
 export const en: Record<string, string> = {
+  // Home
+  "home.title": "Veckomenyn",
+  "home.subtitle": "Plan a week, build the cart, order, retrospect.",
+  "home.plan_new": "Plan a new week",
+  "home.plan_first": "Plan your first week",
+  "home.your_weeks": "Your weeks",
+  "home.empty_title": "Welcome.",
+  "home.empty_body":
+    "This is where the family's weeks live. The agent helps you plan dinners, builds the grocery cart, and learns from each week's feedback.",
+  "home.loop_step_plan": "Plan dinners for the week.",
+  "home.loop_step_cart": "Let the agent build the Willys cart.",
+  "home.loop_step_order": "Place the order on willys.se.",
+  "home.loop_step_retro": "Record a retrospective so next week is better.",
+
   // Top bar
+  "topbar.brand_home": "Home",
   "topbar.working": "agent working",
   "topbar.stop": "Stop",
   "topbar.refresh": "Refresh",

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -1,5 +1,20 @@
 export const sv: Record<string, string> = {
+  // Home
+  "home.title": "Veckomenyn",
+  "home.subtitle": "Planera en vecka, bygg kundvagnen, beställ, blicka tillbaka.",
+  "home.plan_new": "Planera en ny vecka",
+  "home.plan_first": "Planera din första vecka",
+  "home.your_weeks": "Dina veckor",
+  "home.empty_title": "Välkommen.",
+  "home.empty_body":
+    "Här bor familjens veckor. Agenten hjälper dig planera middagar, bygger kundvagnen och lär sig av varje veckas återblick.",
+  "home.loop_step_plan": "Planera middagar för veckan.",
+  "home.loop_step_cart": "Låt agenten bygga Willys-kundvagnen.",
+  "home.loop_step_order": "Beställ på willys.se.",
+  "home.loop_step_retro": "Skriv en återblick så nästa vecka blir bättre.",
+
   // Top bar
+  "topbar.brand_home": "Hem",
   "topbar.working": "agenten arbetar",
   "topbar.stop": "Stoppa",
   "topbar.refresh": "Uppdatera",

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -5,19 +5,19 @@ import { useSyncExternalStore } from "react";
 // deep-linking all work the same way. A plan is identified by its numeric id
 // so the permalink points at one specific plan; iso_week is a label only.
 export type Route =
-  | { kind: "current" } //          /
-  | { kind: "week"; id: number } //         /weeks/:id
-  | { kind: "new" } //              /weeks/new
-  | { kind: "print"; id: number } //        /weeks/:id/print
-  | { kind: "settings" } //         /settings
-  | { kind: "preferences" } //      /preferences
-  | { kind: "usage" } //            /usage
-  | { kind: "setup" }; //           /setup
+  | { kind: "home" } //                      /
+  | { kind: "week"; id: number } //          /weeks/:id
+  | { kind: "new" } //                       /weeks/new
+  | { kind: "print"; id: number } //         /weeks/:id/print
+  | { kind: "settings" } //                  /settings
+  | { kind: "preferences" } //               /preferences
+  | { kind: "usage" } //                     /usage
+  | { kind: "setup" }; //                    /setup
 
 const ID_RE = /^\d+$/;
 
 export function parseRoute(pathname: string): Route {
-  if (pathname === "/" || pathname === "") return { kind: "current" };
+  if (pathname === "/" || pathname === "") return { kind: "home" };
   if (pathname === "/weeks/new") return { kind: "new" };
   if (pathname === "/settings") return { kind: "settings" };
   if (pathname === "/preferences") return { kind: "preferences" };
@@ -30,12 +30,12 @@ export function parseRoute(pathname: string): Route {
     if (parts.length === 2) return { kind: "week", id };
     if (parts.length === 3 && parts[2] === "print") return { kind: "print", id };
   }
-  return { kind: "current" };
+  return { kind: "home" };
 }
 
 export function routeToPath(route: Route): string {
   switch (route.kind) {
-    case "current":
+    case "home":
       return "/";
     case "week":
       return `/weeks/${route.id}`;
@@ -83,7 +83,7 @@ export function navigate(route: Route | string, options?: { replace?: boolean })
 
 // goBack returns to the previous in-app URL if possible, otherwise navigates
 // to the fallback (useful for modals opened directly from a bookmark).
-export function goBack(fallback: Route = { kind: "current" }): void {
+export function goBack(fallback: Route = { kind: "home" }): void {
   if (window.history.length > 1) window.history.back();
   else navigate(fallback, { replace: true });
 }


### PR DESCRIPTION
The root URL no longer auto-redirects to whichever week happens to be "current". Instead it renders a home view with a primary "Plan a new week" CTA, a list of existing weeks, and an empty-state intro for fresh installs.

## Changes

- New route \`kind: "home"\` mapped to \`/\`.
- New \`HomeView\` component (CTA card, week list grouped by recency, brief loop explainer when no weeks exist yet).
- Brand in the topbar is now a link back to home.
- \`SetupWizard\`'s post-completion redirect points at home.
- \`navigate({ kind: "current" })\` callsites updated to \`{ kind: "home" }\`; the \`current\` programmatic action is gone since home no longer auto-resolves.

## Stacked

Based on #14 because \`HomeView\` uses the global toast for fetch errors (\`listWeeks\` failures). Will rebase to \`main\` once #14 merges.

Closes #7.