### PR TITLE
fix(willys): use /search instead of /search/clean

### DIFF
--- a/internal/willys/client.go
+++ b/internal/willys/client.go
@@ -331,7 +331,7 @@ func (c *Client) Search(query string, page, size int) (SearchResult, error) {
 		"size": {strconv.Itoa(size)},
 		"page": {strconv.Itoa(page)},
 	}
-	resp, err := c.do(http.MethodGet, "/search/clean?"+params.Encode(), nil)
+	resp, err := c.do(http.MethodGet, "/search?"+params.Encode(), nil)
 	if err != nil {
 		return SearchResult{}, err
 	}

--- a/internal/willys/client_test.go
+++ b/internal/willys/client_test.go
@@ -92,6 +92,32 @@ func TestParseSearchResult(t *testing.T) {
 	}
 }
 
+func TestSearchUsesMultiWordEndpoint(t *testing.T) {
+	// Willys has two search endpoints: /search/clean returns a degenerate
+	// single-token match (q=färsk koriander → Färskost). /search does proper
+	// multi-word relevance. We must hit /search.
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[],"pagination":{}}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c.baseOverride = srv.URL
+	if _, err := c.Search("färsk koriander", 0, 10); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if gotPath != "/search" {
+		t.Errorf("path = %q, want %q", gotPath, "/search")
+	}
+	if gotQuery != "färsk koriander" {
+		t.Errorf("q = %q, want %q", gotQuery, "färsk koriander")
+	}
+}
+
 func TestParseOrderDetail(t *testing.T) {
 	raw := `{
 		"orderNumber":"3057837654",


### PR DESCRIPTION
## Summary
- `/search/clean` ignores everything past the first token when ranking, so `q=färsk koriander` returns Färskost products instead of fresh coriander.
- The Willys SPA itself uses `/search` (`getSearchResultsUsingGet1`). Same JSON shape, just better relevance.
- Pinned with a test that fails on `/search/clean`.

Closes #18

## Test plan
- [x] `go test ./internal/willys/`
- [ ] Manual smoke: ask the agent for a multi-word ingredient and confirm the right product comes back