### PR TITLE
feat(updates): manual "Check for updates" trigger in Settings

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,6 +117,7 @@ func (s *Server) routes() {
 		r.Get("/health", s.handleHealth)
 		r.Get("/version", s.handleVersion)
 		r.Get("/updates", s.handleGetUpdates)
+		r.Post("/updates/check", s.handleCheckUpdates)
 		r.Post("/updates/apply", s.handleApplyUpdate)
 		r.Get("/update-config", s.handleGetUpdateConfig)
 		r.Patch("/update-config", s.handlePatchUpdateConfig)
@@ -173,6 +174,17 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetUpdates(w http.ResponseWriter, r *http.Request) {
+	s.respondWithUpdateStatus(w, r, false)
+}
+
+// handleCheckUpdates forces a fresh upstream check, bypassing the 1h cache.
+// Wired to a button in Settings so users can verify a freshly cut release
+// is visible without waiting out the TTL or restarting the server.
+func (s *Server) handleCheckUpdates(w http.ResponseWriter, r *http.Request) {
+	s.respondWithUpdateStatus(w, r, true)
+}
+
+func (s *Server) respondWithUpdateStatus(w http.ResponseWriter, r *http.Request, force bool) {
 	canApply := s.updateTrigger != nil && s.updateTrigger.Configured()
 
 	autoEnabled := false
@@ -193,9 +205,16 @@ func (s *Server) handleGetUpdates(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	status, err := s.updates.Status(r.Context())
+
+	var status updates.Status
+	var err error
+	if force {
+		status, err = s.updates.Refresh(r.Context())
+	} else {
+		status, err = s.updates.Status(r.Context())
+	}
 	if err != nil {
-		s.log.Warn("update check failed", "err", err)
+		s.log.Warn("update check failed", "err", err, "forced", force)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"current":      status.Current,

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -23,10 +23,11 @@ type Status struct {
 }
 
 type Checker struct {
-	repo       string
-	current    string
-	httpClient *http.Client
-	ttl        time.Duration
+	repo        string
+	current     string
+	httpClient  *http.Client
+	ttl         time.Duration
+	releasesURL string // overridable for tests
 
 	mu        sync.Mutex
 	cached    *Status
@@ -39,10 +40,11 @@ type Checker struct {
 // update available.
 func New(repo, current string) *Checker {
 	return &Checker{
-		repo:       repo,
-		current:    current,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
-		ttl:        time.Hour,
+		repo:        repo,
+		current:     current,
+		httpClient:  &http.Client{Timeout: 10 * time.Second},
+		ttl:         time.Hour,
+		releasesURL: "https://api.github.com/repos/" + repo + "/releases/latest",
 	}
 }
 
@@ -57,7 +59,17 @@ func (c *Checker) Status(ctx context.Context) (Status, error) {
 		return s, nil
 	}
 	c.mu.Unlock()
+	return c.fetchAndCache(ctx)
+}
 
+// Refresh forces a fresh upstream fetch, bypassing the TTL cache. Used by
+// the manual "check for updates" button so users don't have to wait out
+// the cache window when verifying that a freshly cut release is visible.
+func (c *Checker) Refresh(ctx context.Context) (Status, error) {
+	return c.fetchAndCache(ctx)
+}
+
+func (c *Checker) fetchAndCache(ctx context.Context) (Status, error) {
 	latest, url, err := c.fetchLatest(ctx)
 	if err != nil {
 		c.mu.Lock()
@@ -84,8 +96,7 @@ func (c *Checker) Status(ctx context.Context) (Status, error) {
 }
 
 func (c *Checker) fetchLatest(ctx context.Context) (string, string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET",
-		"https://api.github.com/repos/"+c.repo+"/releases/latest", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", c.releasesURL, nil)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -1,6 +1,74 @@
 package updates
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestStatusServesCachedWithinTTL(t *testing.T) {
+	var calls int32
+	srv := newReleaseServer(t, &calls, "v0.5.0")
+	defer srv.Close()
+
+	c := New("simonnordberg/veckomenyn", "0.4.0")
+	c.httpClient = srv.Client()
+	c.releasesURL = srv.URL
+
+	if _, err := c.Status(context.Background()); err != nil {
+		t.Fatalf("first Status: %v", err)
+	}
+	if _, err := c.Status(context.Background()); err != nil {
+		t.Fatalf("second Status: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (cache hit on second)", got)
+	}
+}
+
+func TestRefreshBypassesCache(t *testing.T) {
+	var calls int32
+	srv := newReleaseServer(t, &calls, "v0.5.0")
+	defer srv.Close()
+
+	c := New("simonnordberg/veckomenyn", "0.4.0")
+	c.httpClient = srv.Client()
+	c.releasesURL = srv.URL
+
+	if _, err := c.Status(context.Background()); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	s, err := c.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (refresh must bypass cache)", got)
+	}
+	if !s.HasUpdate || s.Latest != "0.5.0" {
+		t.Errorf("status = %+v, want HasUpdate with latest 0.5.0", s)
+	}
+	// Cache should now be primed; next Status() should not call upstream.
+	if _, err := c.Status(context.Background()); err != nil {
+		t.Fatalf("Status after Refresh: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("upstream calls after follow-up Status = %d, want 2 (cache hit)", got)
+	}
+}
+
+func newReleaseServer(t *testing.T, calls *int32, tag string) *httptest.Server {
+	t.Helper()
+	body := `{"tag_name":"` + tag + `","html_url":"https://example.test/r"}`
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
 
 func TestCmp(t *testing.T) {
 	cases := []struct {

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -69,7 +69,6 @@ func newReleaseServer(t *testing.T, calls *int32, tag string) *httptest.Server {
 	}))
 }
 
-
 func TestCmp(t *testing.T) {
 	cases := []struct {
 		a, b string

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { t, useLang } from "../i18n";
 import { applyUpdate, getUpdates, getVersion, type UpdateStatus } from "../lib/api";
+import { UPDATES_REFRESHED_EVENT } from "./UpdatesSection";
 
 const DISMISSED_KEY = "veckomenyn.update.dismissed";
 const UPGRADED_FROM_KEY = "veckomenyn.update.upgraded_from";
@@ -45,19 +46,35 @@ export function UpdateBanner() {
     };
   }, []);
 
+  // Initial fetch + re-fetch when Settings dispatches a manual check, so
+  // the banner appears (or disappears) inline without needing a reload.
   useEffect(() => {
     let cancelled = false;
-    getUpdates()
-      .then((s) => {
-        if (!cancelled) setStatus(s);
-      })
-      .catch(() => {
-        /* silently keep banner hidden on error */
-      });
+    const fetchStatus = () => {
+      getUpdates()
+        .then((s) => {
+          if (!cancelled) setStatus(s);
+        })
+        .catch(() => {
+          /* silently keep banner hidden on error */
+        });
+    };
+    fetchStatus();
+    window.addEventListener(UPDATES_REFRESHED_EVENT, fetchStatus);
     return () => {
       cancelled = true;
+      window.removeEventListener(UPDATES_REFRESHED_EVENT, fetchStatus);
     };
   }, []);
+
+  // If the user dismissed an older version, allow the banner to reappear
+  // when a newer one shows up.
+  useEffect(() => {
+    if (status?.latest && dismissed && status.latest !== dismissed) {
+      window.localStorage.removeItem(DISMISSED_KEY);
+      setDismissed("");
+    }
+  }, [status?.latest, dismissed]);
 
   // Post-update success toast, rendered independently of the
   // available-update banner so it shows even when there's nothing new.

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { t, useLang } from "../i18n";
 import { applyUpdate, getUpdates, getVersion, type UpdateStatus } from "../lib/api";
-import { UPDATES_REFRESHED_EVENT } from "./UpdatesSection";
+import { UPDATES_REFRESHED_EVENT } from "../lib/events";
 
 const DISMISSED_KEY = "veckomenyn.update.dismissed";
 const UPGRADED_FROM_KEY = "veckomenyn.update.upgraded_from";

--- a/web/src/components/UpdatesSection.tsx
+++ b/web/src/components/UpdatesSection.tsx
@@ -1,12 +1,25 @@
 import { useEffect, useState } from "react";
 import { t, useLang } from "../i18n";
-import { getUpdateConfig, patchUpdateConfig, type UpdateConfig } from "../lib/api";
+import {
+  checkUpdates,
+  getUpdateConfig,
+  patchUpdateConfig,
+  type UpdateConfig,
+  type UpdateStatus,
+} from "../lib/api";
+
+// UpdateBanner listens for this event and re-fetches its status when it
+// fires, so a manual check from Settings reflects in the banner without
+// a full page reload.
+export const UPDATES_REFRESHED_EVENT = "veckomenyn:updates-refreshed";
 
 export function UpdatesSection() {
   useLang();
   const [cfg, setCfg] = useState<UpdateConfig | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [checkResult, setCheckResult] = useState<UpdateStatus | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -32,6 +45,20 @@ export function UpdatesSection() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(false);
+    }
+  };
+
+  const onCheck = async () => {
+    setChecking(true);
+    setError(null);
+    try {
+      const status = await checkUpdates();
+      setCheckResult(status);
+      window.dispatchEvent(new Event(UPDATES_REFRESHED_EVENT));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setChecking(false);
     }
   };
 
@@ -74,6 +101,24 @@ export function UpdatesSection() {
           {t("update.auto_unavailable")}
         </p>
       )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void onCheck()}
+          disabled={checking}
+          className="rounded-md border border-stone-300 bg-white px-3 py-1 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
+        >
+          {checking ? t("update.checking") : t("update.check_now")}
+        </button>
+        {checkResult && !checking && (
+          <span className="text-xs text-stone-600 dark:text-stone-400">
+            {checkResult.has_update
+              ? t("update.found", { version: checkResult.latest })
+              : t("update.up_to_date", { version: checkResult.current })}
+          </span>
+        )}
+      </div>
     </section>
   );
 }

--- a/web/src/components/UpdatesSection.tsx
+++ b/web/src/components/UpdatesSection.tsx
@@ -7,11 +7,7 @@ import {
   type UpdateConfig,
   type UpdateStatus,
 } from "../lib/api";
-
-// UpdateBanner listens for this event and re-fetches its status when it
-// fires, so a manual check from Settings reflects in the banner without
-// a full page reload.
-export const UPDATES_REFRESHED_EVENT = "veckomenyn:updates-refreshed";
+import { UPDATES_REFRESHED_EVENT } from "../lib/events";
 
 export function UpdatesSection() {
   useLang();
@@ -51,6 +47,7 @@ export function UpdatesSection() {
   const onCheck = async () => {
     setChecking(true);
     setError(null);
+    setCheckResult(null);
     try {
       const status = await checkUpdates();
       setCheckResult(status);

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -321,6 +321,10 @@ export const en: Record<string, string> = {
   "update.auto_label": "Apply updates automatically",
   "update.auto_hint": "Hourly check; if a newer version is published, restart with the new image.",
   "update.auto_unavailable": "Auto-update needs the Watchtower trigger sidecar. See deploy docs.",
+  "update.check_now": "Check for updates",
+  "update.checking": "Checking…",
+  "update.up_to_date": "You're on the latest version (v{version}).",
+  "update.found": "Update available: v{version}.",
 
   "setup.welcome_title": "Welcome to Veckomenyn",
   "setup.welcome_body":

--- a/web/src/i18n/sv.ts
+++ b/web/src/i18n/sv.ts
@@ -325,6 +325,10 @@ export const sv: Record<string, string> = {
     "Kontrollerar varje timme; om en nyare version finns startas appen om med den nya imagen.",
   "update.auto_unavailable":
     "Automatiska uppdateringar kräver Watchtower-sidecar. Se distributionsdokumentationen.",
+  "update.check_now": "Sök efter uppdateringar",
+  "update.checking": "Kollar…",
+  "update.up_to_date": "Du har senaste versionen (v{version}).",
+  "update.found": "Uppdatering tillgänglig: v{version}.",
 
   "setup.welcome_title": "Välkommen till Veckomenyn",
   "setup.welcome_body":

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -425,6 +425,13 @@ export async function getUpdates(): Promise<UpdateStatus> {
   return (await r.json()) as UpdateStatus;
 }
 
+// checkUpdates forces a fresh upstream check, bypassing the 1h cache.
+export async function checkUpdates(): Promise<UpdateStatus> {
+  const r = await fetch("/api/updates/check", { method: "POST" });
+  if (!r.ok) throw new Error(`updates/check: ${r.status}`);
+  return (await r.json()) as UpdateStatus;
+}
+
 export async function applyUpdate(): Promise<void> {
   const r = await fetch("/api/updates/apply", { method: "POST" });
   if (!r.ok && r.status !== 202) throw new Error(await r.text());

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -1,0 +1,8 @@
+// Cross-component window events. Define the name in one place so the
+// dispatcher and listener don't need to import each other just to share
+// a string constant.
+
+// Fires when the user manually triggers an update check from Settings.
+// UpdateBanner listens and re-fetches its status so the banner reflects
+// the new state inline.
+export const UPDATES_REFRESHED_EVENT = "veckomenyn:updates-refreshed";


### PR DESCRIPTION
## Summary
- The hourly TTL on the GitHub release check makes it awkward to trial-update a freshly cut release on the home server.
- Adds `Checker.Refresh()` (bypasses cache, refreshes it), `POST /api/updates/check`, and a "Check for updates" button in Settings.
- After a successful check, the section dispatches a window event the existing `UpdateBanner` listens for, so the banner reflects the new state inline (no full page reload).

Closes #22

## Test plan
- [x] `go test ./internal/updates/` (new TTL-cached + Refresh-bypasses-cache tests)
- [x] `make verify` (build, race tests, golangci-lint, web tsc + biome + build)
- [ ] Manual on the local server: open Settings → Updates → click "Check for updates"; confirm the inline result reflects the latest GitHub release and the top banner appears when one is available.