### PR TITLE
ci: cross-compile Go in Dockerfile to skip QEMU on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ COPY web/ ./
 RUN pnpm build
 
 # ---- Go binaries ----------------------------------------------------------
-FROM golang:1.26-alpine AS go
+# Pin to BUILDPLATFORM so the Go toolchain runs natively on the runner,
+# then cross-compile to TARGETOS/TARGETARCH. Without this the arm64 build
+# runs under QEMU emulation and takes ~6 minutes; cross-compiled it
+# matches the amd64 build at ~40s.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS go
 WORKDIR /app
 RUN apk add --no-cache ca-certificates
 COPY go.mod go.sum ./
@@ -28,8 +32,10 @@ COPY --from=web /app/web/dist ./web/dist
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILT_AT=unknown
+ARG TARGETOS
+ARG TARGETARCH
 ENV CGO_ENABLED=0
-RUN go build -trimpath \
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
         -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILT_AT}" \
         -o /out/veckomenyn ./cmd/veckomenyn
 


### PR DESCRIPTION
## Summary

- Pin the `go` build stage to `--platform=$BUILDPLATFORM` so the Go toolchain runs natively on the runner.
- Cross-compile to `TARGETOS`/`TARGETARCH`. The runtime stage still resolves per-arch through the multi-arch `alpine` index, so the published manifest list is unchanged.

The arm64 build was previously running under QEMU emulation (~6 min in CI). Cross-compiled, Go produces arm64 binaries on the amd64 runner with no emulator in the loop.

Stacked on #25 — base set to `chore/drop-import-tools`. Will retarget to `main` once that lands.

Refs #24 (build-time half).

## Local verification

```
docker buildx build --platform linux/amd64,linux/arm64 ...
```

- Total end-to-end: **~1m 27s** (was ~10m 28s in CI)
- arm64 Go build step: **10.3s** (was 376.4s in v0.4.4 release)
- Output binary: `ELF 64-bit LSB executable, ARM aarch64, ... statically linked, Go BuildID=...` (verified via `docker create --platform linux/arm64` + `file`)

## Test plan

- [x] Multi-arch buildx succeeds locally
- [x] arm64 binary is genuine aarch64 ELF
- [x] amd64 binary is unchanged in shape (same ldflags)
- [ ] CI release dry-run on next tag shows reduced time