### PR TITLE
feat(agent): update_exception and delete_exception tools

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -320,7 +320,7 @@ func currentPlanBlock(ctx context.Context, db *pgxpool.Pool, log *slog.Logger) a
   status: %s
   dinners: %d
 </current-plan>
-This chat is tied to the plan above. Assume every user request refers to it. When calling week-scoped tools (add_dinner, update_week, update_dinner, delete_dinner, add_exception, record_retrospective, get_week), omit week_id or pass id=%d; any other value will be refused. If the user wants to edit a different plan, tell them to open it and try there.`, id, iso, start, end, status, dinnerCount, id)
+This chat is tied to the plan above. Assume every user request refers to it. When calling week-scoped tools (add_dinner, update_week, update_dinner, delete_dinner, add_exception, update_exception, delete_exception, record_retrospective, get_week), omit week_id or pass id=%d; any other value will be refused. If the user wants to edit a different plan, tell them to open it and try there.`, id, iso, start, end, status, dinnerCount, id)
 	return anthropic.TextBlockParam{Text: text}
 }
 

--- a/internal/agent/system.md
+++ b/internal/agent/system.md
@@ -4,8 +4,8 @@ You are the meal-planning agent for a family that orders groceries from Willys.s
 
 Each chat is tied to one plan. When the user's view has a plan loaded, a `<current-plan>` block appears in your system prompt with its id, date range, and status. Every request the user sends in this chat refers to that plan unless they explicitly say otherwise.
 
-- Omit `week_id` on tool calls; the plan-scoped tools (`add_dinner`, `update_week`, `update_dinner`, `delete_dinner`, `add_exception`, `record_retrospective`, `get_week`) default to the current plan.
-- Passing a different `week_id` is refused. `update_dinner` / `delete_dinner` also refuse if the dinner belongs to a different plan.
+- Omit `week_id` on tool calls; the plan-scoped tools (`add_dinner`, `update_week`, `update_dinner`, `delete_dinner`, `add_exception`, `update_exception`, `delete_exception`, `record_retrospective`, `get_week`) default to the current plan.
+- Passing a different `week_id` is refused. `update_dinner` / `delete_dinner` / `update_exception` / `delete_exception` also refuse if the row belongs to a different plan.
 - If the user asks to edit a different plan, tell them to open it first and run the request there. Don't try to reach into another plan from this chat.
 
 ## How a plan works
@@ -29,7 +29,7 @@ When a plan already has some dinners scheduled (e.g. from a clone where the targ
 3. Ask clarifying questions only when something material is unclear (delivery date, headcount for a given day, allergies that conflict with a request). Otherwise make reasonable assumptions and propose a plan.
 4. When planning an existing plan (the common case), skip `create_week`; the plan already exists and is the one in scope. Call `add_dinner` per day. Write the full recipe in `recipe_md` (ingredients + numbered steps + technique notes). Set `sourcing_json` only when the family's preferences say a given item doesn't come from Willys. Use `create_week` only when the user explicitly asks to start a brand new plan from scratch.
 5. If the user asks to replace one dinner, call `update_dinner` on just that row. Do not regenerate the whole week.
-6. Record week-level context (kids away, extra bake) as `add_exception` entries so the plan reflects reality.
+6. Record week-level context (kids away, extra bake) as `add_exception` entries so the plan reflects reality. If the user corrects or cancels one, use `update_exception` or `delete_exception` rather than adding a new contradicting one.
 7. When the user gives feedback after a week, call `record_retrospective` and, if the feedback implies a persistent change, also call `update_preference` so the lesson sticks.
 8. Use `willys_search` when you need a product code to add to the cart, or to check availability of an ingredient.
 

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -69,6 +69,8 @@ func registerTools(db *pgxpool.Pool, shop shopping.Provider, log *slog.Logger) [
 		updateDinnerTool(db),
 		deleteDinnerTool(db),
 		addExceptionTool(db),
+		updateExceptionTool(db),
+		deleteExceptionTool(db),
 		recordRetrospectiveTool(db),
 	}
 	if shop != nil {
@@ -940,6 +942,78 @@ func addExceptionTool(db *pgxpool.Pool) Tool {
 				return "", err
 			}
 			return fmt.Sprintf("added exception id=%d (%s: %s)", id, in.Kind, in.Description), nil
+		},
+	)
+}
+
+func updateExceptionTool(db *pgxpool.Pool) Tool {
+	return newTool(
+		"update_exception",
+		"Edit a plan-level exception. Pass exception_id plus any of kind / description; omitted fields stay as they were. Refuses if the exception belongs to a different plan or the plan is locked.",
+		map[string]any{
+			"exception_id": map[string]any{"type": "integer"},
+			"kind":         map[string]any{"type": "string", "description": "Optional new kind: 'absence', 'extra_meal', 'bake', 'other'."},
+			"description":  map[string]any{"type": "string", "description": "Optional new description."},
+		},
+		[]string{"exception_id"},
+		func(ctx context.Context, input json.RawMessage) (string, error) {
+			var in struct {
+				ExceptionID int64   `json:"exception_id"`
+				Kind        *string `json:"kind"`
+				Description *string `json:"description"`
+			}
+			if err := json.Unmarshal(input, &in); err != nil {
+				return "", err
+			}
+			if in.Kind == nil && in.Description == nil {
+				return "", fmt.Errorf("nothing to update: pass kind and/or description")
+			}
+			if err := ensureExceptionEditable(ctx, db, in.ExceptionID); err != nil {
+				return "", err
+			}
+			tag, err := db.Exec(ctx, `
+				UPDATE week_exceptions
+				SET kind = COALESCE($2, kind),
+				    description = COALESCE($3, description)
+				WHERE id = $1`,
+				in.ExceptionID, in.Kind, in.Description)
+			if err != nil {
+				return "", err
+			}
+			if tag.RowsAffected() == 0 {
+				return fmt.Sprintf("no exception with id=%d", in.ExceptionID), nil
+			}
+			return fmt.Sprintf("updated exception id=%d", in.ExceptionID), nil
+		},
+	)
+}
+
+func deleteExceptionTool(db *pgxpool.Pool) Tool {
+	return newTool(
+		"delete_exception",
+		"Remove a plan-level exception. Refuses if the exception belongs to a different plan or the plan is locked.",
+		map[string]any{
+			"exception_id": map[string]any{"type": "integer"},
+		},
+		[]string{"exception_id"},
+		func(ctx context.Context, input json.RawMessage) (string, error) {
+			var in struct {
+				ExceptionID int64 `json:"exception_id"`
+			}
+			if err := json.Unmarshal(input, &in); err != nil {
+				return "", err
+			}
+			if err := ensureExceptionEditable(ctx, db, in.ExceptionID); err != nil {
+				return "", err
+			}
+			tag, err := db.Exec(ctx, `DELETE FROM week_exceptions WHERE id=$1`, in.ExceptionID)
+			if err != nil {
+				return "", err
+			}
+			if tag.RowsAffected() == 0 {
+				return fmt.Sprintf("no exception with id=%d", in.ExceptionID), nil
+			}
+			return fmt.Sprintf("deleted exception id=%d", in.ExceptionID), nil
 		},
 	)
 }

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -971,7 +971,7 @@ func updateExceptionTool(db *pgxpool.Pool) Tool {
 			if err := ensureExceptionEditable(ctx, db, in.ExceptionID); err != nil {
 				return "", err
 			}
-			tag, err := db.Exec(ctx, `
+			_, err := db.Exec(ctx, `
 				UPDATE week_exceptions
 				SET kind = COALESCE($2, kind),
 				    description = COALESCE($3, description)
@@ -979,9 +979,6 @@ func updateExceptionTool(db *pgxpool.Pool) Tool {
 				in.ExceptionID, in.Kind, in.Description)
 			if err != nil {
 				return "", err
-			}
-			if tag.RowsAffected() == 0 {
-				return fmt.Sprintf("no exception with id=%d", in.ExceptionID), nil
 			}
 			return fmt.Sprintf("updated exception id=%d", in.ExceptionID), nil
 		},
@@ -1006,12 +1003,8 @@ func deleteExceptionTool(db *pgxpool.Pool) Tool {
 			if err := ensureExceptionEditable(ctx, db, in.ExceptionID); err != nil {
 				return "", err
 			}
-			tag, err := db.Exec(ctx, `DELETE FROM week_exceptions WHERE id=$1`, in.ExceptionID)
-			if err != nil {
+			if _, err := db.Exec(ctx, `DELETE FROM week_exceptions WHERE id=$1`, in.ExceptionID); err != nil {
 				return "", err
-			}
-			if tag.RowsAffected() == 0 {
-				return fmt.Sprintf("no exception with id=%d", in.ExceptionID), nil
 			}
 			return fmt.Sprintf("deleted exception id=%d", in.ExceptionID), nil
 		},

--- a/internal/agent/tools_db_test.go
+++ b/internal/agent/tools_db_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -176,6 +177,146 @@ func TestSearchHistory_excludesCurrentWeekDishes(t *testing.T) {
 			t.Errorf("current-week dish leaked into scoped search: %q", out)
 		}
 	})
+}
+
+// seedException inserts a week_exceptions row and returns its id.
+func seedException(t *testing.T, pool *pgxpool.Pool, weekID int64, kind, description string) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(t.Context(), `
+		INSERT INTO week_exceptions (week_id, kind, description)
+		VALUES ($1, $2, $3) RETURNING id`,
+		weekID, kind, description).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert exception: %v", err)
+	}
+	return id
+}
+
+func TestUpdateException(t *testing.T) {
+	pool := setupTestDB(t)
+	ctx := t.Context()
+
+	dish := seedDish(t, pool, "Pasta")
+	weekID := seedWeek(t, pool, "2026-W17", "2026-04-21", "2026-04-27", dish)
+	excID := seedException(t, pool, weekID, "absence", "Noah away Thu")
+
+	scoped := WithWeekID(ctx, weekID)
+	tool := updateExceptionTool(pool)
+
+	t.Run("updates description only", func(t *testing.T) {
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `, "description": "Noah away Thu-Sun"}`)
+		out, err := tool.Call(scoped, input)
+		if err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		if !strings.Contains(out, "updated exception") {
+			t.Errorf("unexpected result: %q", out)
+		}
+		var k, d string
+		if err := pool.QueryRow(ctx, `SELECT kind, description FROM week_exceptions WHERE id=$1`, excID).Scan(&k, &d); err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		if k != "absence" {
+			t.Errorf("kind changed unexpectedly: %q", k)
+		}
+		if d != "Noah away Thu-Sun" {
+			t.Errorf("description not updated: %q", d)
+		}
+	})
+
+	t.Run("updates kind only", func(t *testing.T) {
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `, "kind": "other"}`)
+		if _, err := tool.Call(scoped, input); err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		var k string
+		if err := pool.QueryRow(ctx, `SELECT kind FROM week_exceptions WHERE id=$1`, excID).Scan(&k); err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		if k != "other" {
+			t.Errorf("kind not updated: %q", k)
+		}
+	})
+
+	t.Run("rejects empty payload", func(t *testing.T) {
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `}`)
+		if _, err := tool.Call(scoped, input); err == nil {
+			t.Error("expected error on empty payload")
+		}
+	})
+
+	t.Run("rejects cross-plan id", func(t *testing.T) {
+		dish2 := seedDish(t, pool, "Sallad")
+		other := seedWeek(t, pool, "2026-W18", "2026-04-28", "2026-05-04", dish2)
+		otherExc := seedException(t, pool, other, "bake", "fika")
+
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(otherExc) + `, "description": "x"}`)
+		if _, err := tool.Call(scoped, input); err == nil {
+			t.Error("expected refusal on cross-plan exception")
+		}
+	})
+
+	t.Run("rejects locked plan", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `UPDATE weeks SET status='ordered' WHERE id=$1`, weekID); err != nil {
+			t.Fatalf("lock: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = pool.Exec(ctx, `UPDATE weeks SET status='draft' WHERE id=$1`, weekID)
+		})
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `, "description": "y"}`)
+		if _, err := tool.Call(scoped, input); err == nil {
+			t.Error("expected refusal on locked plan")
+		}
+	})
+}
+
+func TestDeleteException(t *testing.T) {
+	pool := setupTestDB(t)
+	ctx := t.Context()
+
+	dish := seedDish(t, pool, "Pasta")
+	weekID := seedWeek(t, pool, "2026-W17", "2026-04-21", "2026-04-27", dish)
+	excID := seedException(t, pool, weekID, "absence", "Noah away Thu")
+
+	scoped := WithWeekID(ctx, weekID)
+	tool := deleteExceptionTool(pool)
+
+	t.Run("deletes on draft plan", func(t *testing.T) {
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `}`)
+		out, err := tool.Call(scoped, input)
+		if err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		if !strings.Contains(out, "deleted exception") {
+			t.Errorf("unexpected result: %q", out)
+		}
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM week_exceptions WHERE id=$1`, excID).Scan(&n); err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected row gone, count=%d", n)
+		}
+	})
+
+	t.Run("rejects locked plan", func(t *testing.T) {
+		other := seedException(t, pool, weekID, "bake", "fika")
+		if _, err := pool.Exec(ctx, `UPDATE weeks SET status='ordered' WHERE id=$1`, weekID); err != nil {
+			t.Fatalf("lock: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = pool.Exec(ctx, `UPDATE weeks SET status='draft' WHERE id=$1`, weekID)
+		})
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(other) + `}`)
+		if _, err := tool.Call(scoped, input); err == nil {
+			t.Error("expected refusal on locked plan")
+		}
+	})
+}
+
+func jsonInt(i int64) string {
+	return strconv.FormatInt(i, 10)
 }
 
 // Compile-time guard that we're using the same context.Context type as the

--- a/internal/agent/tools_db_test.go
+++ b/internal/agent/tools_db_test.go
@@ -239,6 +239,20 @@ func TestUpdateException(t *testing.T) {
 		}
 	})
 
+	t.Run("updates both fields", func(t *testing.T) {
+		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `, "kind": "absence", "description": "Noah away Fri"}`)
+		if _, err := tool.Call(scoped, input); err != nil {
+			t.Fatalf("call: %v", err)
+		}
+		var k, d string
+		if err := pool.QueryRow(ctx, `SELECT kind, description FROM week_exceptions WHERE id=$1`, excID).Scan(&k, &d); err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		if k != "absence" || d != "Noah away Fri" {
+			t.Errorf("both fields not updated: kind=%q description=%q", k, d)
+		}
+	})
+
 	t.Run("rejects empty payload", func(t *testing.T) {
 		input := json.RawMessage(`{"exception_id": ` + jsonInt(excID) + `}`)
 		if _, err := tool.Call(scoped, input); err == nil {

--- a/internal/agent/wkctx.go
+++ b/internal/agent/wkctx.go
@@ -116,3 +116,16 @@ func EnsureDinnerEditable(ctx context.Context, db rowQueryer, dinnerID int64) er
 	}
 	return EnsureEditable(ctx, db, weekID)
 }
+
+// ensureExceptionEditable enforces both the chat-binding scope check and
+// the plan-status editability guard for week_exceptions mutations.
+func ensureExceptionEditable(ctx context.Context, db rowQueryer, exceptionID int64) error {
+	var weekID int64
+	if err := db.QueryRow(ctx, `SELECT week_id FROM week_exceptions WHERE id = $1`, exceptionID).Scan(&weekID); err != nil {
+		return err
+	}
+	if curr := WeekIDFrom(ctx); curr != 0 && weekID != curr {
+		return fmt.Errorf("exception id=%d belongs to plan id=%d; this chat is tied to plan id=%d. Ask the user to open that plan to edit it", exceptionID, weekID, curr)
+	}
+	return EnsureEditable(ctx, db, weekID)
+}


### PR DESCRIPTION
## Summary

- Add `update_exception` (COALESCE-style partial updates of `kind` / `description`) and `delete_exception` agent tools.
- New `ensureExceptionEditable` helper enforces the same chat-binding scope check and locked-plan refusal as `update_dinner` / `delete_dinner`.
- System prompt and chat-binding doc string list the new tools alongside `add_exception`.

Closes #27.

## Test plan

- [x] `go build ./...` clean
- [x] New tests pass against a Postgres test DB:
  - `TestUpdateException/updates_description_only`
  - `TestUpdateException/updates_kind_only`
  - `TestUpdateException/rejects_empty_payload`
  - `TestUpdateException/rejects_cross-plan_id`
  - `TestUpdateException/rejects_locked_plan`
  - `TestDeleteException/deletes_on_draft_plan`
  - `TestDeleteException/rejects_locked_plan`
- [x] Full `internal/agent` test suite green
- [x] `make verify` passes (pre-push hook)
- [ ] CI green