### PR TITLE
fix(willys): reject anonymous session after login

### DIFF
--- a/internal/willys/client.go
+++ b/internal/willys/client.go
@@ -115,9 +115,9 @@ func (c *Client) ClearState() {
 	}
 }
 
-// IsAuthError reports whether an error came from a rejected authentication
-// (HTTP 401/403, or a /login that returned 200 but resolved to an anonymous
-// session — Willys does that when credentials are wrong).
+// IsAuthError reports whether an error came from a rejected authentication.
+// That covers HTTP 401/403, and the case where /login returns 200 but the
+// resulting session is anonymous (which is how Willys signals bad creds).
 func IsAuthError(err error) bool {
 	var ae *authErr
 	return errors.As(err, &ae)

--- a/internal/willys/client.go
+++ b/internal/willys/client.go
@@ -115,7 +115,9 @@ func (c *Client) ClearState() {
 	}
 }
 
-// IsAuthError reports whether an error came from a 401/403 response.
+// IsAuthError reports whether an error came from a rejected authentication
+// (HTTP 401/403, or a /login that returned 200 but resolved to an anonymous
+// session — Willys does that when credentials are wrong).
 func IsAuthError(err error) bool {
 	var ae *authErr
 	return errors.As(err, &ae)
@@ -123,9 +125,13 @@ func IsAuthError(err error) bool {
 
 type authErr struct {
 	status int
+	reason string
 }
 
 func (e *authErr) Error() string {
+	if e.reason != "" {
+		return fmt.Sprintf("auth failed: %s", e.reason)
+	}
 	return fmt.Sprintf("auth failed: %d", e.status)
 }
 
@@ -269,8 +275,13 @@ func (c *Client) Login(username, password string) (Customer, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		c.ClearState()
+		return Customer{}, &authErr{status: resp.StatusCode}
+	}
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
+		c.ClearState()
 		return Customer{}, fmt.Errorf("login failed (%d): %s", resp.StatusCode, body)
 	}
 
@@ -290,9 +301,26 @@ func (c *Client) Login(username, password string) (Customer, error) {
 	if err != nil {
 		return Customer{}, err
 	}
+	// Willys returns 200 even when credentials are wrong; the resulting
+	// session is anonymous. Reject it so cart/order operations can't run
+	// on a guest account.
+	if !isAuthenticated(cust) {
+		c.ClearState()
+		return Customer{}, &authErr{status: http.StatusUnauthorized, reason: "anonymous session after login (bad credentials)"}
+	}
 
 	c.saveSession()
 	return cust, nil
+}
+
+// isAuthenticated reports whether a Customer payload represents a real
+// logged-in user. The Willys backend returns name="anonymous" for guest
+// sessions; real users always have a UID and a first name.
+func isAuthenticated(cust Customer) bool {
+	if cust.Name == "anonymous" {
+		return false
+	}
+	return cust.UID != "" && cust.FirstName != ""
 }
 
 // IsLoggedIn checks if the saved session is still valid.

--- a/internal/willys/client_test.go
+++ b/internal/willys/client_test.go
@@ -284,7 +284,7 @@ func TestGetProduct(t *testing.T) {
 
 // fakeWillysServer returns a httptest server that mimics the endpoints the
 // real Willys.se backend exposes for login. customerJSON is what /customer
-// will return — pass an "anonymous" body to simulate bad credentials, since
+// will return; pass an "anonymous" body to simulate bad credentials, since
 // the real backend returns 200 on /login regardless and only the customer
 // payload reveals whether auth actually succeeded.
 func fakeWillysServer(t *testing.T, customerJSON string) *httptest.Server {

--- a/internal/willys/client_test.go
+++ b/internal/willys/client_test.go
@@ -282,6 +282,71 @@ func TestGetProduct(t *testing.T) {
 	}
 }
 
+// fakeWillysServer returns a httptest server that mimics the endpoints the
+// real Willys.se backend exposes for login. customerJSON is what /customer
+// will return — pass an "anonymous" body to simulate bad credentials, since
+// the real backend returns 200 on /login regardless and only the customer
+// payload reveals whether auth actually succeeded.
+func fakeWillysServer(t *testing.T, customerJSON string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/config", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "sess"})
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/axfood/rest/csrf-token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`"csrf-token"`))
+	})
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/axfood/rest/customer", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(customerJSON))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestLoginRejectsAnonymousResponse(t *testing.T) {
+	srv := fakeWillysServer(t, `{"name":"anonymous"}`)
+	defer srv.Close()
+
+	store := &FileSessionStore{Path: filepath.Join(t.TempDir(), "session.json")}
+	c := NewClientWithStore(store)
+	c.baseOverride = srv.URL
+
+	_, err := c.Login("bad", "creds")
+	if err == nil {
+		t.Fatal("Login: want error for anonymous response, got nil")
+	}
+	if !IsAuthError(err) {
+		t.Errorf("IsAuthError(err) = false; want true (err=%v)", err)
+	}
+	if c.IsLoggedIn() {
+		t.Error("IsLoggedIn = true after rejected login; want false")
+	}
+	if _, statErr := os.Stat(store.Path); !os.IsNotExist(statErr) {
+		t.Error("session file should not be saved when login is rejected")
+	}
+}
+
+func TestLoginSucceedsForRealCustomer(t *testing.T) {
+	srv := fakeWillysServer(t, `{"uid":"u-1","name":"Alice","firstName":"Alice"}`)
+	defer srv.Close()
+
+	c := NewClientWithStore(&FileSessionStore{Path: filepath.Join(t.TempDir(), "session.json")})
+	c.baseOverride = srv.URL
+
+	cust, err := c.Login("good", "creds")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if cust.FirstName != "Alice" {
+		t.Errorf("FirstName = %q, want %q", cust.FirstName, "Alice")
+	}
+}
+
 func TestSessionRoundTrip(t *testing.T) {
 	store := &FileSessionStore{Path: filepath.Join(t.TempDir(), "session.json")}
 


### PR DESCRIPTION
Closes #29.

## Summary
- `Login` now validates the customer payload returned after `POST /login`. Willys returns 200 with an anonymous customer when credentials are wrong; the previous code persisted that as a valid session and cart/order operations silently ran against a guest account.
- On a rejected login the client clears its state (no anonymous cookies on disk) and returns a real `authErr`, so `IsAuthError` finally returns true and the existing retry path in `WillysProvider.withAuth` engages.
- 401/403 responses on `/login` itself are now also surfaced as `authErr` instead of a generic message.

## Test plan
- [x] `go test ./internal/willys/...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/willys/...`
- [ ] Manual: set a wrong Willys password in Settings, confirm cart/orders surface an auth error instead of returning a guest cart.