### PR TITLE
fix(compose): support rootless podman for the watchtower sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,5 @@
 # Podman. Rootless Podman users must override: that socket is owned
 # root:docker on the host and the rootless container can't access it.
 # Use the user's own podman socket instead, typically
-# /run/user/<uid>/podman/podman.sock.
-# WATCHTOWER_SOCK=/run/user/1000/podman/podman.sock
+# /run/user/<uid>/podman/podman.sock (run `id -u` for your uid).
+# WATCHTOWER_SOCK=/run/user/<uid>/podman/podman.sock

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,11 @@
 # MASTER_KEY=<base64-32-bytes> and uncomment the line in compose.
 # Generate: openssl rand -base64 32
 # MASTER_KEY=
+
+# Docker-API-compatible socket the watchtower sidecar talks to. The
+# default /var/run/docker.sock works for rootful Docker and rootful
+# Podman. Rootless Podman users must override: that socket is owned
+# root:docker on the host and the rootless container can't access it.
+# Use the user's own podman socket instead, typically
+# /run/user/<uid>/podman/podman.sock.
+# WATCHTOWER_SOCK=/run/user/1000/podman/podman.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,13 @@ services:
   # can't eat your data.
   watchtower:
     image: containrrr/watchtower:latest
+    # On SELinux-enforcing hosts (Fedora, RHEL) the rootless podman
+    # socket is labelled user_tmp_t and the container's container_t
+    # domain can't reach it. Disabling labelling for this single
+    # sidecar lets it talk to the host socket without relabelling
+    # the systemd-managed socket file. No-op on Ubuntu/Debian.
+    security_opt:
+      - label=disable
     environment:
       # Pin the Docker Engine API version. Without this, the docker SDK
       # negotiates a too-old version that modern daemons reject. 1.44
@@ -79,7 +86,12 @@ services:
       DOCKER_API_VERSION: "1.44"
       WATCHTOWER_HTTP_API_TOKEN: ${WATCHTOWER_TOKEN:-veckomenyn-internal}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Default is the rootful Docker / rootful Podman socket. Rootless
+      # Podman users override with WATCHTOWER_SOCK in .env, since the
+      # host /var/run/docker.sock is owned root:docker and the rootless
+      # container has no access to it. Typical override:
+      #   WATCHTOWER_SOCK=/run/user/1000/podman/podman.sock
+      - ${WATCHTOWER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
     command:
       - --label-enable
       - --cleanup

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,6 +11,12 @@ open http://localhost:8080
 
 That pulls `ghcr.io/simonnordberg/veckomenyn:0.5` from GHCR, the patch channel for the 0.5 line. The app generates and persists its own AES master key on first boot, so there's no `.env` ritual. Podman is the default; `docker compose up -d` works the same way.
 
+> **Rootless podman:** before the first `up`, write the path to your own podman socket into `.env` so the watchtower sidecar can reach it. The default `/var/run/docker.sock` is owned `root:docker` and a rootless container can't read it.
+>
+> ```sh
+> echo "WATCHTOWER_SOCK=/run/user/$(id -u)/podman/podman.sock" >> .env
+> ```
+
 The first request triggers a setup wizard:
 
 1. LAN-only warning.

--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,10 @@ err() { printf '%s\n' "$*" >&2; }
 # script uses $COMPOSE so we can address whichever one is present.
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   COMPOSE="docker compose"
+  ENGINE="docker"
 elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
   COMPOSE="podman compose"
+  ENGINE="podman"
 else
   err "Neither docker nor podman (with the compose plugin) is installed."
   err ""
@@ -116,6 +118,16 @@ if ! grep -q '^WATCHTOWER_TOKEN=' .env; then
     token=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
   fi
   printf 'WATCHTOWER_TOKEN=%s\n' "$token" >> .env
+fi
+
+# Rootless podman can't read /var/run/docker.sock (root:docker). Point
+# watchtower at the user's own podman socket instead. Skipped when a
+# WATCHTOWER_SOCK is already set or when running rootful.
+if [ "$ENGINE" = "podman" ] && [ "$(id -u)" -ne 0 ] && ! grep -q '^WATCHTOWER_SOCK=' .env; then
+  podman_sock="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+  if [ -S "$podman_sock" ]; then
+    printf 'WATCHTOWER_SOCK=%s\n' "$podman_sock" >> .env
+  fi
 fi
 chmod 600 .env
 


### PR DESCRIPTION
Closes #17.

## Summary
- `docker-compose.yml`: socket path is now overridable via `WATCHTOWER_SOCK` (default `/var/run/docker.sock`, so rootful Docker/Podman is unaffected).
- Add `security_opt: label=disable` so SELinux-enforcing hosts (Fedora, RHEL) can reach the host-managed socket without relabelling it (the systemd user socket can't be relabelled without breaking the unit).
- `install.sh`: detects rootless podman and writes the right socket path into `.env` automatically.
- `.env.example`: documents the override.

## Test plan
- [x] Manual: rootless podman on Fedora 43 (SELinux enforcing); watchtower now connects to the user socket and goes idle as designed.
- [x] `podman compose config` parses the file cleanly.