### PR TITLE
fix(willys): guard cart and order ops on the client itself

### DIFF
--- a/internal/willys/client.go
+++ b/internal/willys/client.go
@@ -24,12 +24,13 @@ const (
 // Safe for concurrent use. Mutable session state (cookies, CSRF token) is
 // protected by mu; the underlying *http.Client is already safe.
 type Client struct {
-	http         *http.Client
-	mu           sync.RWMutex      // protects cookies, csrfToken
-	cookies      map[string]string // guarded by mu
-	csrfToken    string            // guarded by mu
-	baseOverride string            // test-only, immutable after construction
-	store        SessionStore      // itself safe for concurrent use
+	http          *http.Client
+	mu            sync.RWMutex      // protects cookies, csrfToken, authenticated
+	cookies       map[string]string // guarded by mu
+	csrfToken     string            // guarded by mu
+	authenticated bool              // guarded by mu; true only after Login confirms a real user
+	baseOverride  string            // test-only, immutable after construction
+	store         SessionStore      // itself safe for concurrent use
 }
 
 // NewClient creates a new Willys API client backed by the default file
@@ -109,10 +110,28 @@ func (c *Client) ClearState() {
 	c.mu.Lock()
 	c.cookies = map[string]string{}
 	c.csrfToken = ""
+	c.authenticated = false
 	c.mu.Unlock()
 	if c.store != nil {
 		_ = c.store.Clear(context.Background())
 	}
+}
+
+// requireAuth gates user-scoped operations. It refuses to make the request
+// unless a successful Login has set the authenticated flag. The cookie-based
+// session alone is not enough: /api/config hands out anonymous JSESSIONIDs,
+// and the cart endpoint cheerfully serves an empty guest cart against one.
+func (c *Client) requireAuth() error {
+	if c.IsLoggedIn() {
+		return nil
+	}
+	return &authErr{status: http.StatusUnauthorized, reason: "not logged in"}
+}
+
+func (c *Client) setAuthenticated(v bool) {
+	c.mu.Lock()
+	c.authenticated = v
+	c.mu.Unlock()
 }
 
 // IsAuthError reports whether an error came from a rejected authentication.
@@ -309,6 +328,7 @@ func (c *Client) Login(username, password string) (Customer, error) {
 		return Customer{}, &authErr{status: http.StatusUnauthorized, reason: "anonymous session after login (bad credentials)"}
 	}
 
+	c.setAuthenticated(true)
 	c.saveSession()
 	return cust, nil
 }
@@ -323,19 +343,14 @@ func isAuthenticated(cust Customer) bool {
 	return cust.UID != "" && cust.FirstName != ""
 }
 
-// IsLoggedIn checks if the saved session is still valid.
+// IsLoggedIn reports whether the client believes it has a confirmed session.
+// Pure getter: it does not contact Willys. The flag is set true at the end of
+// a successful Login and reset by ClearState; a remotely-expired session is
+// caught by the 401 retry in WillysProvider.withAuth.
 func (c *Client) IsLoggedIn() bool {
 	c.mu.RLock()
-	hasCookies := len(c.cookies) > 0
-	c.mu.RUnlock()
-	if !hasCookies {
-		return false
-	}
-	cust, err := c.GetCustomer()
-	if err != nil {
-		return false
-	}
-	return cust.FirstName != "" && cust.Name != "anonymous"
+	defer c.mu.RUnlock()
+	return c.authenticated
 }
 
 // GetCustomer returns the logged-in user's profile.
@@ -424,6 +439,9 @@ func (c *Client) Browse(categoryPath string, page, size int) (SearchResult, erro
 
 // GetCart returns the current shopping cart.
 func (c *Client) GetCart() (Cart, error) {
+	if err := c.requireAuth(); err != nil {
+		return Cart{}, err
+	}
 	resp, err := c.do(http.MethodGet, "/axfood/rest/cart", nil)
 	if err != nil {
 		return Cart{}, err
@@ -446,6 +464,9 @@ type addProductEntry struct {
 
 // AddToCart adds products to the cart and returns the updated cart.
 func (c *Client) AddToCart(code string, qty int) (Cart, error) {
+	if err := c.requireAuth(); err != nil {
+		return Cart{}, err
+	}
 	if c.needsCSRF() {
 		if err := c.fetchCSRFToken(); err != nil {
 			return Cart{}, err
@@ -480,6 +501,9 @@ func (c *Client) RemoveFromCart(code string) (Cart, error) {
 // GetOrderHistory returns the order history for the logged-in user.
 // The API may return either a raw array or an object with an "orders" key.
 func (c *Client) GetOrderHistory() ([]OrderSummary, error) {
+	if err := c.requireAuth(); err != nil {
+		return nil, err
+	}
 	resp, err := c.do(http.MethodGet, "/axfood/rest/account/orders", nil)
 	if err != nil {
 		return nil, err
@@ -508,6 +532,9 @@ func (c *Client) GetOrderHistory() ([]OrderSummary, error) {
 
 // GetOrderDetail returns the full details of a single order.
 func (c *Client) GetOrderDetail(orderNumber string) (OrderDetail, error) {
+	if err := c.requireAuth(); err != nil {
+		return OrderDetail{}, err
+	}
 	params := url.Values{
 		"q": {orderNumber},
 	}
@@ -525,6 +552,9 @@ func (c *Client) GetOrderDetail(orderNumber string) (OrderDetail, error) {
 
 // ClearCart removes all products from the cart.
 func (c *Client) ClearCart() error {
+	if err := c.requireAuth(); err != nil {
+		return err
+	}
 	if c.needsCSRF() {
 		if err := c.fetchCSRFToken(); err != nil {
 			return err

--- a/internal/willys/client_test.go
+++ b/internal/willys/client_test.go
@@ -17,7 +17,7 @@ func TestParseOrderHistory_Array(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c := &Client{http: srv.Client(), cookies: map[string]string{}, authenticated: true}
 	c.baseOverride = srv.URL
 	orders, err := c.GetOrderHistory()
 	if err != nil {
@@ -39,7 +39,7 @@ func TestParseOrderHistory_Wrapper(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c := &Client{http: srv.Client(), cookies: map[string]string{}, authenticated: true}
 	c.baseOverride = srv.URL
 	orders, err := c.GetOrderHistory()
 	if err != nil {
@@ -57,7 +57,7 @@ func TestParseOrderHistory_Empty(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c := &Client{http: srv.Client(), cookies: map[string]string{}, authenticated: true}
 	c.baseOverride = srv.URL
 	orders, err := c.GetOrderHistory()
 	if err != nil {
@@ -105,7 +105,7 @@ func TestSearchUsesMultiWordEndpoint(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c := &Client{http: srv.Client(), cookies: map[string]string{}, authenticated: true}
 	c.baseOverride = srv.URL
 	if _, err := c.Search("färsk koriander", 0, 10); err != nil {
 		t.Fatalf("Search: %v", err)
@@ -261,7 +261,7 @@ func TestGetProduct(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{http: srv.Client(), cookies: map[string]string{}}
+	c := &Client{http: srv.Client(), cookies: map[string]string{}, authenticated: true}
 	c.baseOverride = srv.URL
 
 	p, err := c.GetProduct("101206348_ST")
@@ -344,6 +344,49 @@ func TestLoginSucceedsForRealCustomer(t *testing.T) {
 	}
 	if cust.FirstName != "Alice" {
 		t.Errorf("FirstName = %q, want %q", cust.FirstName, "Alice")
+	}
+}
+
+// TestAuthedOpsRequireLogin proves the structural invariant: cart and order
+// operations on the client must refuse to run unless Login has succeeded.
+// Without this, a stray JSESSIONID from /api/config (or stale cookies from
+// disk) is enough for Willys to serve an anonymous cart, and a hole in
+// the provider layer would leak through.
+func TestAuthedOpsRequireLogin(t *testing.T) {
+	srv := fakeWillysServer(t, `{"name":"anonymous"}`)
+	defer srv.Close()
+
+	c := NewClientWithStore(&FileSessionStore{Path: filepath.Join(t.TempDir(), "session.json")})
+	c.baseOverride = srv.URL
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"GetCart", func() error { _, err := c.GetCart(); return err }},
+		{"AddToCart", func() error { _, err := c.AddToCart("ABC", 1); return err }},
+		{"RemoveFromCart", func() error { _, err := c.RemoveFromCart("ABC"); return err }},
+		{"ClearCart", func() error { return c.ClearCart() }},
+		{"GetOrderHistory", func() error { _, err := c.GetOrderHistory(); return err }},
+		{"GetOrderDetail", func() error { _, err := c.GetOrderDetail("X"); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if err == nil {
+				t.Fatal("want auth error before login, got nil")
+			}
+			if !IsAuthError(err) {
+				t.Errorf("IsAuthError(err) = false; want true (err=%v)", err)
+			}
+		})
+	}
+
+	// And also: a rejected (anonymous) login must not flip the client into
+	// an authenticated state, so the same ops still fail afterwards.
+	_, _ = c.Login("bad", "creds")
+	if _, err := c.GetCart(); err == nil || !IsAuthError(err) {
+		t.Errorf("GetCart after rejected login: err=%v, want auth error", err)
 	}
 }
 


### PR DESCRIPTION
Closes #32.

Follow-up to #30. That PR closed the symptom at the provider layer (\`Login\` rejects anonymous sessions, \`ensureLoggedIn\` errors before the cart call runs). This one closes the underlying gap: the \`willys.Client\` itself shouldn't be willing to make cart/order calls without a confirmed login, regardless of how it's wired up.

## Summary
- Add \`authenticated\` flag on \`Client\`, set only after \`Login\` or \`IsLoggedIn\` confirms a real customer.
- Reset the flag in \`ClearState\` and whenever \`IsLoggedIn\` finds an anonymous response.
- New \`requireAuth()\` guard on \`GetCart\`, \`AddToCart\`, \`RemoveFromCart\`, \`ClearCart\`, \`GetOrderHistory\`, \`GetOrderDetail\`. \`Search\`, \`GetProduct\`, \`GetCustomer\` stay open (anonymous-friendly or part of the auth handshake).
- New \`TestAuthedOpsRequireLogin\` table-tests every gated op against the bare client and after a rejected login.

## Live verification
Standalone probe against \`https://www.willys.se\` with bad credentials, before/after this PR:

\`\`\`
=== before ===
GetCart OK: items=0 total=""        # leaked guest cart
GetOrderHistory error: 401

=== after ===
GetCart error: auth failed: not logged in
GetOrderHistory error: auth failed: not logged in
\`\`\`

## Test plan
- [x] \`go test ./...\`
- [x] \`golangci-lint run\`
- [x] Manual: standalone probe with bad credentials returns auth error from both \`GetCart\` and \`GetOrderHistory\`.
- [ ] Manual after deploy: set wrong Willys password in Settings, confirm chat says auth error for both cart and orders.