### PR TITLE
fix(agent): tell willys_search to query bare ingredient names

### DIFF
--- a/internal/agent/system.md
+++ b/internal/agent/system.md
@@ -48,7 +48,7 @@ Before you call `willys_search` or any cart tool, you must produce a consolidate
    - fresh parsley: salsa verde (2) + shakshuka (1) + meatloaf (1) = 4 bunches
 5. **Subtract what's already in the cart.** For each aggregated ingredient, check the list from step 1. If a matching product (by name, fuzzy is fine: "lök" covers "Lök Gul Klass 1") is already there, drop it from the add list and note it as "redan i kundvagn". Don't re-add, and don't add a second variant of the same thing.
 6. **One product per ingredient.** Never add two overlapping variants of the same thing: no loose + bagged of the same onion, no two brands of the same spice, no Garant + non-Garant of the same product. If you change your mind mid-build, `willys_cart_remove` the old before adding the new.
-7. `willys_search` for each *distinct* ingredient still on the list. Pick the best match (Garant / Swedish / loose where applicable) and note the code and chosen qty.
+7. `willys_search` for each *distinct* ingredient still on the list. Query the bare ingredient name (`lök`, `mango`, `tomat`, `färsk koriander`); never append quality grades (`klass 1`), brands, weights, or pack sizes. The search matches all terms, so qualifiers filter out valid hits ("mango klass 1" finds nothing; "mango" returns the products you can then choose from). Pick the best match from the results (Garant / Swedish / loose where applicable) and note the code and chosen qty.
 8. Submit the delta with one `willys_cart_add_many`.
 9. Call `willys_cart_get` at the end and compare against your aggregated list (existing + newly added). If anything's missing, over-quantified, or duplicated, fix it now, not after the user points it out.
 


### PR DESCRIPTION
Closes #34.

## Summary
- The agent was tacking `klass 1` onto Willys searches (e.g. `mango klass 1`), missing every product whose name doesn't contain that grade. `/search` matches all terms, so qualifiers filter out valid hits.
- Step 7 of the cart-building method now spells out the query shape: bare ingredient name only; brand / grade / weight / pack-size selection happens against the *result list*, not the query.

## Test plan
- [ ] Plan a week and watch the agent's `willys_search` calls: queries should look like `mango`, `lök`, `färsk koriander`, never `mango klass 1`.
- [ ] Confirm produce that previously came back empty (mango, oliver, etc.) now resolves to a product code on the first search.