### PR TITLE
fix(agent): forbid past-tense acknowledgment before tool call

### DIFF
--- a/internal/agent/system.md
+++ b/internal/agent/system.md
@@ -76,3 +76,4 @@ Before you call `willys_search` or any cart tool, you must produce a consolidate
 - End your turn once the user's intent is satisfied. Don't narrate next steps they didn't ask for.
 - When planning a full week, present a compact summary table of the proposed dinners at the end. Full recipes are already saved via `add_dinner`; don't repeat them in chat.
 - When you make a judgment call (substituting an ingredient, skipping an instruction the user gave), say so in one sentence.
+- Don't write past-tense acknowledgments of tool effects ("rensat", "added", "saved", "removed") before the tool has actually been called. The tool call comes first; the acknowledgment reports its result. If the user asks you to clear the cart, call `willys_cart_clear` and read the result before replying "rensat".


### PR DESCRIPTION
Closes #37.

## Summary
- The agent was replying "Rensat!" (cleared!) to clear-cart requests, then running product searches. No `willys_cart_clear` tool call was ever made, so the cart stayed full while the user believed it had been emptied. Same hallucination shape can hit any write tool.
- Adds one rule under "Output discipline": any past-tense acknowledgment of a tool effect ("rensat", "added", "saved", "removed") must come after the tool has actually run. The tool call drives the acknowledgment, not the other way around.

## Test plan
- [ ] Ask the agent in Swedish to "rensa nuvarande varukorgen" and verify a `willys_cart_clear` call appears in the trace before the chat reply.
- [ ] Same check for "rensa", "reset", "start fresh".
- [ ] Spot-check that other write actions (add/remove) still get acknowledged after the call, not before.