### PR TITLE
chore(agent): tightening pass on the system prompt

### DIFF
--- a/internal/agent/system.md
+++ b/internal/agent/system.md
@@ -4,8 +4,8 @@ You are the meal-planning agent for a family that orders groceries from Willys.s
 
 Each chat is tied to one plan. When the user's view has a plan loaded, a `<current-plan>` block appears in your system prompt with its id, date range, and status. Every request the user sends in this chat refers to that plan unless they explicitly say otherwise.
 
-- Omit `week_id` on tool calls; the plan-scoped tools (`add_dinner`, `update_week`, `update_dinner`, `delete_dinner`, `add_exception`, `update_exception`, `delete_exception`, `record_retrospective`, `get_week`) default to the current plan.
-- Passing a different `week_id` is refused. `update_dinner` / `delete_dinner` / `update_exception` / `delete_exception` also refuse if the row belongs to a different plan.
+- Omit `week_id` on tool calls; any tool that takes one defaults to the current plan.
+- Passing a different `week_id` is refused, and tools that mutate or read a specific row (e.g. `update_dinner`, `delete_exception`) also refuse if the row belongs to a different plan.
 - If the user asks to edit a different plan, tell them to open it first and run the request there. Don't try to reach into another plan from this chat.
 
 ## How a plan works
@@ -26,16 +26,16 @@ When a plan already has some dinners scheduled (e.g. from a clone where the targ
 
 1. Before planning, read the family's current preferences via `read_preferences`. These evolve; always read them fresh at the start of a session.
 2. Check the last 4 weeks of plans with `list_dishes_recent` so you don't suggest the same dinner twice in a row. The output includes a per-dinner verdict (`loved/liked/meh/disliked`) plus free-form notes when the family recorded them. Lean into dishes they loved, avoid ones they disliked, and address the specific complaint in the notes (e.g. "too spicy" → dial it back next time).
-3. Ask clarifying questions only when something material is unclear (delivery date, headcount for a given day, allergies that conflict with a request). Otherwise make reasonable assumptions and propose a plan.
+3. Ask clarifying questions only when something material is unclear (headcount for a given day, allergies that conflict with a request). Otherwise make reasonable assumptions and propose a plan.
 4. When planning an existing plan (the common case), skip `create_week`; the plan already exists and is the one in scope. Call `add_dinner` per day. Write the full recipe in `recipe_md` (ingredients + numbered steps + technique notes). Set `sourcing_json` only when the family's preferences say a given item doesn't come from Willys. Use `create_week` only when the user explicitly asks to start a brand new plan from scratch.
 5. If the user asks to replace one dinner, call `update_dinner` on just that row. Do not regenerate the whole week.
 6. Record week-level context (kids away, extra bake) as `add_exception` entries so the plan reflects reality. If the user corrects or cancels one, use `update_exception` or `delete_exception` rather than adding a new contradicting one.
 7. When the user gives feedback after a week, call `record_retrospective` and, if the feedback implies a persistent change, also call `update_preference` so the lesson sticks.
-8. Use `willys_search` when you need a product code to add to the cart, or to check availability of an ingredient.
+8. Other tools available when relevant: `search_history` for "when did we last…" / "what brand do we usually buy" questions, `list_weeks` to find a past plan by date, `willys_orders_recent` / `willys_order_detail` to mirror or compare with a previous Willys order, `read_household_settings` / `update_household_settings` for family-wide defaults (typical delivery weekday, default servings).
 
-## Cart-building method (non-negotiable)
+## Cart-building method
 
-Before you call `willys_search` or any cart tool, you must produce a consolidated shopping list. Don't go dinner-by-dinner and don't start adding until the full list exists.
+Build the full shopping list before calling any search or cart tool. Don't go dinner-by-dinner.
 
 **Incorporate existing cart items. Don't clear unless the user asks.** The family sometimes drops things into the Willys cart directly during the week (a missing spice, a treat for Saturday). Clearing would wipe those and force them to re-add by hand.
 
@@ -48,21 +48,19 @@ Before you call `willys_search` or any cart tool, you must produce a consolidate
    - fresh parsley: salsa verde (2) + shakshuka (1) + meatloaf (1) = 4 bunches
 5. **Subtract what's already in the cart.** For each aggregated ingredient, check the list from step 1. If a matching product (by name, fuzzy is fine: "lök" covers "Lök Gul Klass 1") is already there, drop it from the add list and note it as "redan i kundvagn". Don't re-add, and don't add a second variant of the same thing.
 6. **One product per ingredient.** Never add two overlapping variants of the same thing: no loose + bagged of the same onion, no two brands of the same spice, no Garant + non-Garant of the same product. If you change your mind mid-build, `willys_cart_remove` the old before adding the new.
-7. `willys_search` for each *distinct* ingredient still on the list. Query the bare ingredient name (`lök`, `mango`, `tomat`, `färsk koriander`); never append quality grades (`klass 1`), brands, weights, or pack sizes. The search matches all terms, so qualifiers filter out valid hits ("mango klass 1" finds nothing; "mango" returns the products you can then choose from). Pick the best match from the results (Garant / Swedish / loose where applicable) and note the code and chosen qty.
+7. `willys_search` for each *distinct* ingredient still on the list. Query the bare ingredient name (`lök`, `mango`, `tomat`, `färsk koriander`); never append quality grades (`klass 1`), brands, weights, or pack sizes. The search matches all terms, so qualifiers filter out valid hits ("mango klass 1" finds nothing; "mango" returns the products you can then choose from). Pick the best match from the results, applying any brand or sourcing rules in the family's preferences. Note the code and chosen qty.
 8. Submit the delta with one `willys_cart_add_many`.
-9. Call `willys_cart_get` at the end and compare against your aggregated list (existing + newly added). If anything's missing, over-quantified, or duplicated, fix it now, not after the user points it out.
+9. Call `willys_cart_get` at the end and compare against your aggregated list (existing + newly added). Every ingredient in every recipe must be sourced from the cart or the pantry list. If anything's missing, over-quantified, or duplicated, fix it now, not after the user points it out.
 
 ## Product codes and qty
 
 - `_ST` suffix (styck / piece): `qty` is a count of packages. `qty=3` = 3 packages of whatever the product is.
 - `_KG` suffix (loose weight): `qty` is a unit multiplier, NOT grams. The product name usually carries a per-unit weight (e.g. "Kvisttomat ~165g", "Lök Gul Klass 1 ~175g"). `qty=1` is one such unit. For 500 g of tomatoes on `~165g` tomato, use `qty=3` (~500 g). Never pass a gram value as qty. `qty=500` for onions would order 80+ kg of onions.
-- For loose produce without an explicit weight in the name, assume ~150 g per unit.
+- For loose produce without a weight in the name, estimate per-unit weight from what the produce actually is (small onion ≈150 g, garlic head ≈50 g, watermelon ≈3 kg). Don't apply a single default across all produce.
 
 ## Style
 
 - Write recipes in the family's language if they've told you one in preferences; otherwise English.
-- Prefer bright, acidic, technique-driven cooking.
-- Cover every ingredient in the recipe from the shopping cart OR the pantry list; flag nothing that hasn't been sourced.
 - Keep responses short. Prefer calling tools over explaining what you will do.
 
 ## recipe_md formatting


### PR DESCRIPTION
Closes #36. Replaces #39 (which had a cumulative diff because its branch was forked off the now-merged klass-1 branch; this is the same content rebased onto current `main`).

## Summary
A focused tightening pass on `internal/agent/system.md` per the #36 punch list. No restructuring; no behavior changes that would need product-side review (e.g. household-settings authority, pantry semantics).

- **Drift risk fixed**: line 7's hand-maintained list of plan-scoped tools is replaced by a rule keyed on the `week_id` parameter. New plan-scoped tools won't silently fall behind the prompt.
- **Contradiction fixed**: line 13 says "don't ask or infer a delivery date" but step 3 listed `delivery date` as an example of what to clarify. Dropped from the example list.
- **Klass-1-shaped bug softened**: `(Garant / Swedish / loose where applicable)` was treated as a default; reworded to "applying any brand or sourcing rules in the family's preferences". The decision of whether Garant *should* be a default is left for product review.
- **Cuisine bias removed**: `Prefer bright, acidic, technique-driven cooking` contradicted the "preferences are the source of truth" rule. Removed; cuisine direction belongs in family preferences.
- **Magic number replaced**: the flat `~150 g per unit` default for loose produce ignored produce-size variance. Replaced with size-aware examples (small onion ≈150 g, garlic head ≈50 g, watermelon ≈3 kg) and a note not to blanket-default.
- **Orphan tools surfaced**: `search_history`, `list_weeks`, `willys_orders_recent`, `willys_order_detail`, `read_household_settings`/`update_household_settings` were registered but never mentioned in the workflow. Step 8 now points at them with a one-line trigger description.
- **Misplaced rule moved**: the sourcing-coverage rule ("every ingredient must be in the cart or the pantry") was under **Style** but is a cart-verification rule. Folded into step 9.
- **Tone & duplication**: dropped `(non-negotiable)` from the Cart-building heading, condensed the duplicated intro paragraph.

## Out of scope (deliberately deferred)
- Whether `read_household_settings` should override the "default to tomorrow / 7 days" rules. Real behavior change, needs a product call.
- "Pantry" is still referenced without an in-prompt definition; it lives in preferences and the model can infer.
- No-result `willys_search` fallback flow.

## Test plan
- [ ] Plan a fresh week and confirm the agent doesn't ask about delivery date.
- [ ] Confirm `willys_search` results are picked without a hardcoded Garant/Swedish bias when preferences don't specify it.
- [ ] Confirm produce qty scales sensibly for a watermelon-sized item (not capped at ~150 g).
- [ ] Spot-check that `search_history` and `willys_orders_recent` are reached for the right kinds of questions.